### PR TITLE
Add `template` and `checkout` args to `make template`

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -181,7 +181,7 @@ requirements requirements/: $(foreach file,$(wildcard requirements/*.in),$(basen
 .PHONY: template
 $(call help,make template,"update from the latest cookiecutter template")
 template: python
-	@pyenv exec tox -e template -- $(cookiecutter)
+	@pyenv exec tox -e template -- $$(if [ -n "$${template+x}" ]; then echo "--template $$template"; fi) $$(if [ -n "$${checkout+x}" ]; then echo "--checkout $$checkout"; fi)
 
 {% if cookiecutter.get("__docker") == "yes" -%}
 DOCKER_TAG = dev

--- a/_shared/project/bin/make_template
+++ b/_shared/project/bin/make_template
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import os
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -14,9 +14,15 @@ extra_context = config.get("extra_context", {})
 extra_context["__ignore__"] = config.get("ignore", [])
 extra_context["__target_dir__"] = Path(os.getcwd())
 
+parser = argparse.ArgumentParser(description="Update the project from the cookiecutter template")
+parser.add_argument("--template", help="the cookiecutter template to use (default: what's in cookiecutter.json)")
+parser.add_argument("--checkout", help="the branch, tag or commit of the cookiecutter template to use (default: main)")
+args = parser.parse_args()
+
 with TemporaryDirectory() as tmpdirname:
     cookiecutter(
-        template=sys.argv[1] if len(sys.argv) >= 2 else config["template"],
+        template=args.template,
+        checkout=args.checkout,
         directory=config["directory"],
         extra_context=extra_context,
         no_input=True,


### PR DESCRIPTION
`make template` in a project updates that project from the `main` branch of `gh:hypothesis/cookiecutters` on GitHub.

This PR adds a `template` argument to `make template` that enable you to update a project from your local copy of the cookiecutter (which may have a development branch checked out and/or may contain local changes, committed or not) instead of from GitHub:

```terminal
make template template=~/Projects/cookiecutters
```

(This already existed but was called `cookiecutter` not `template`, I've updated it to match the argument name used by cookiecutter itself which is `template`).

Secondly this PR adds a `checkout` argument that enables you to update a project from a branch of the cookiecutter rather than from main:

```terminal
make template checkout=foo
```

This will be useful for testing PRs to the cookiecutter repo as you can checkout a project locally ([cookiecutter-pyramid-app-test](https://github.com/hypothesis/cookiecutter-pyramid-app-test) and [cookiecutter-pypackage-test](https://github.com/hypothesis/cookiecutter-pypackage-test) are good projects for this) and then run `make template checkout=pr_branch`.