### PR TITLE
Various tweaks from the pip-sync-faster review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 help:
 	@echo "make help              Print this help message"
 	@echo "make test              Test all the cookiecutters"
+	@echo "make sure              Test all the cookiecutters"
 	@echo "make test-pypackage    Test the pypackage cookiecutter"
 	@echo "make test-pyramid-app  Test the pyramid-app cookiecutter"
 
-.PHONY: test
-test: test-pypackage test-pyramid-app
+.PHONY: test sure
+test sure: test-pypackage test-pyramid-app
 
 .PHONY: test-pypackage
 test-pypackage:

--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -24,6 +24,10 @@ def remove_conditional_files():
     {% endif %}
 
     {% if cookiecutter.get("console_script") != "yes" %}
+    paths_to_remove.extend(["INSTALL.md"])
+    paths_to_remove.extend(["src/{{ cookiecutter.package_name }}/__main__.py"])
+    paths_to_remove.extend(["src/{{ cookiecutter.package_name }}/cli.py"])
+    paths_to_remove.extend(["tests/unit/{{ cookiecutter.package_name }}/cli_test.py"])
     paths_to_remove.extend(["tests/functional/cli_test.py"])
     {% endif %}
 
@@ -136,11 +140,14 @@ def main():
         {%- else %}
         template_ignore_patterns.extend([
             "src/{{ cookiecutter.package_name }}/__init__.py",
-            "src/{{ cookiecutter.package_name }}/main.py",
+            "src/{{ cookiecutter.package_name }}/__main__.py",
+            "src/{{ cookiecutter.package_name }}/core.py",
+            "src/{{ cookiecutter.package_name }}/cli.py",
             "tests/__init__.py",
             "tests/unit/__init__.py",
             "tests/unit/{{ cookiecutter.package_name }}/__init__.py",
-            "tests/unit/{{ cookiecutter.package_name }}/main_test.py",
+            "tests/unit/{{ cookiecutter.package_name }}/core_test.py",
+            "tests/unit/{{ cookiecutter.package_name }}/cli_test.py",
             "tests/functional/__init__.py",
             "tests/functional/cli_test.py",
             "tests/functional/sanity_test.py",

--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -49,11 +49,12 @@ ignore = [
 branch = true
 parallel = true
 source = ["{{ cookiecutter.package_name }}", "tests/unit"]
-{%- if include_exists("coverage/omit") %}
 omit = [
+    "*/{{ cookiecutter.package_name }}/__main__.py",
+    {%- if include_exists("coverage/omit") %}
     {{- include("coverage/omit", indent=4) }}
+    {%- endif %}
 ]
-{%- endif %}
 
 [tool.coverage.paths]
 source = ["src", ".tox/*tests/lib/python*/site-packages"]

--- a/_shared/project/setup.cfg
+++ b/_shared/project/setup.cfg
@@ -32,7 +32,7 @@ console_scripts =
     {{- include("setuptools/console_scripts", indent=4) }}
 {%- elif cookiecutter.get("console_script") == "yes" %}
 console_scripts =
-    {{ cookiecutter.__entry_point }} = {{ cookiecutter.package_name }}.main:entry_point
+    {{ cookiecutter.__entry_point }} = {{ cookiecutter.package_name }}.cli:cli
 {%- endif %}
 {{- include("setuptools/entry_points") }}
 

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -49,6 +49,7 @@ deps =
     lint: pylint
     lint: pydocstyle
     lint: pycodestyle
+    lint,tests: pytest-mock
     lint,tests,coverage: coverage[toml]
     lint,tests,functests: pytest
     lint,tests,functests: factory-boy

--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/__main__.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from {{ cookiecutter.package_name }}.cli import cli
+
+sys.exit(cli())

--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
@@ -1,18 +1,13 @@
-import sys
 from argparse import ArgumentParser
 from importlib.metadata import version
 
 
-def hello_world():
-    return "Hello, world!"
-
-
-def entry_point():  # pragma: nocover
+def cli(_argv=None):  # pylint:disable=inconsistent-return-statements
     parser = ArgumentParser()
     parser.add_argument("-v", "--version", action="store_true")
 
-    args = parser.parse_args()
+    args = parser.parse_args(_argv)
 
     if args.version:
         print(version("{{ cookiecutter.slug }}"))
-        sys.exit()
+        return 0

--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/core.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/core.py
@@ -1,0 +1,2 @@
+def hello_world():
+    return "Hello, world!"

--- a/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
@@ -1,0 +1,23 @@
+from importlib.metadata import version
+
+import pytest
+
+from {{ cookiecutter.package_name }}.cli import cli
+
+
+def test_it():
+    cli([])
+
+
+def test_help():
+    with pytest.raises(SystemExit) as exc_info:
+        cli(["--help"])
+
+    assert not exc_info.value.code
+
+
+def test_version(capsys):
+    exit_code = cli(["--version"])
+
+    assert capsys.readouterr().out.strip() == version("{{ cookiecutter.slug }}")
+    assert not exit_code

--- a/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/core_test.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/core_test.py
@@ -1,4 +1,4 @@
-from {{ cookiecutter.package_name }}.main import hello_world
+from {{ cookiecutter.package_name }}.core import hello_world
 
 
 class TestHelloWorld:


### PR DESCRIPTION
Various tweaks that were suggested in the pip-sync-faster review:

https://github.com/hypothesis/pip-sync-faster/pull/6

Fixes https://github.com/hypothesis/cookiecutters/issues/35

The main thing is the new layout for packages discussed in https://github.com/hypothesis/pip-sync-faster/pull/6#issuecomment-1193120411:

```
pip-sync-faster/
  setup.cfg     <- Declares a console_script that calls cli.py::cli()
  pip_sync_faster/
    __init__.py <- Empty (except maybe some imports)
    __main__.py <- Just imports and calls cli.py::cli()
    cli.py      <- Contains the argparse code and imports and calls something from core.py
    core.py     <- The actual code
  tests/
    unit/
      pip_sync_faster/
        cli_test.py
        core_test.py
```

The other thing is adding `pytest-mock` as a dependency by default.

TODO:

- [x] Make sure that none of the CLI stuff gets generated if `console_script` is not `"yes"`
- [x] Test this against existing projects before merging it
- [x] Test that you can start a project with no CLI and then add one later