### PR TITLE
Make `make sure` depend on `python`

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -127,6 +127,7 @@ $(call help,make {{ target }},"run the functional tests in Python {{ python_vers
 
 .PHONY: sure
 $(call help,make sure,"make sure that the formatting$(comma) linting and tests all pass")
+sure: python
 sure:
 {%- if cookiecutter._directory == 'pyramid-app' %}
 	@pyenv exec tox --parallel -qe 'checkformatting,lint,tests,coverage,functests'


### PR DESCRIPTION
Fixes https://github.com/hypothesis/cookiecutters/issues/48

Testing
=======

Create a Python package to test with. **Note:** the command below creates a Python package from a local copy of the cookiecutter at `~/Projects/cookiecutters`:

```terminal
cd /tmp
cookiecutter ~/Projects/cookiecutters --directory pypackage --no-input
cd my-python-package
```

Uninstall one of the versions of Python that the package needs:

```terminal
pyenv uninstall 3.10.4
```

Run the package's `make sure`:

```terminal
make sure
```

On `main` you'll get a crash because Python 3.10.4 doesn't get reinstalled. On this branch it'll get reinstalled and `make sure` will pass.