### PR TITLE
Add `make devdata` for pypackages

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -19,6 +19,10 @@ def remove_conditional_files():
     paths_to_remove.extend(["package.json", "yarn.lock"])
     {% endif %}
 
+    {% if cookiecutter.get("devdata") != "yes" %}
+    paths_to_remove.extend(["bin/make_devdata"])
+    {% endif %}
+
     {% if cookiecutter.get("services") != "yes" %}
     paths_to_remove.extend(["docker-compose.yml", "requirements/dockercompose.in"])
     {% endif %}

--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -4,19 +4,22 @@ comma := ,
 help = help::; @echo $$$$(tput bold)$(strip $(1)):$$$$(tput sgr0) $(strip $(2))
 $(call help,make help,print this help message)
 
-{%- if cookiecutter.get("_directory") == "pyramid-app" %}
-
 .PHONY: services
+{%- if cookiecutter.get("services") == "yes" %}
 $(call help,make services,start the services that the app needs)
 services: args?=up -d
 services: python
-{%- if cookiecutter.get("services") == "yes" %}
 	@tox -qe dockercompose -- $(args)
 {%- endif %}
 
 .PHONY: devdata
+{%- if cookiecutter.get("devdata") == "yes" %}
 $(call help,make devdata,load development data and environment variables)
 devdata: python
+	@tox -qe dev --run-command 'python bin/make_devdata'
+{%- endif %}
+
+{%- if cookiecutter.get("_directory") == "pyramid-app" %}
 
 .PHONY: dev
 $(call help,make dev,run the whole app \(all workers\))

--- a/_shared/project/bin/make_devdata
+++ b/_shared/project/bin/make_devdata
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import subprocess
+import tempfile
+from pathlib import Path
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        git_dir = Path(tmpdirname) / "devdata"
+        subprocess.check_call(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "git@github.com:hypothesis/devdata.git",
+                git_dir,
+            ]
+        )
+        devdata_file = git_dir / "{{ cookiecutter.slug }}" / "devdata.env"
+        devdata_file.replace(Path(__file__).parent.parent / ".devdata.env")

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -8,6 +8,8 @@
     "copyright_holder": "Hypothesis",
     "visibility": ["public", "private"],
     "console_script": ["no", "yes"],
+    "devdata": ["no", "yes"],
+    "services": ["no", "yes"],
     "create_github_repo": ["no", "yes"],
     "dependabot_pip_interval": ["monthly", "weekly", "daily"],
     "__entry_point": "{{ cookiecutter.slug }}",

--- a/pypackage/{{ cookiecutter.slug }}/bin/make_devdata
+++ b/pypackage/{{ cookiecutter.slug }}/bin/make_devdata
@@ -1,0 +1,1 @@
+../../../_shared/project/bin/make_devdata

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -12,6 +12,7 @@
     "dependabot_pip_interval": ["monthly", "weekly", "daily"],
     "dependabot_npm_interval": ["monthly", "weekly", "daily"],
     "dependabot_docker_interval": ["monthly", "weekly", "daily"],
+    "devdata": ["no", "yes"],
     "frontend": ["no", "yes"],
     "__frontend_typechecking": "{{ cookiecutter.frontend }}",
     "services": ["no", "yes"],

--- a/pyramid-app/{{ cookiecutter.slug }}/bin/make_devdata
+++ b/pyramid-app/{{ cookiecutter.slug }}/bin/make_devdata
@@ -1,0 +1,1 @@
+../../../_shared/project/bin/make_devdata


### PR DESCRIPTION
First add empty `make devdata` and `make services` commands to all projects, Pyramid apps and Python packages, whether they have devdata and services or not. This is just a convenience: it means that `make devdata` and `make services` will work in all projects (even if they do nothing) which makes scripting and documentation easier (because more consistent).

Second, add a working `make devdata` command (and `bin/make_devdata` script that it calls) for projects whose `cookiecutter.json` contains `"devdata": "yes"`. This `make devdata` is tested and working with `pyramid-googleauth`. It will need some adapting when it comes to adding it to other projects: it currently assumes that the project has a `devdata.env` file which may not be true of all projects, and it does not yet support loading data into the project's DB.

The `bin/make_devdata` script of course assumes that the devdata repo contains a `{{ cookiecutter.slug }}/devdata.env` file for the current project, otherwise it'll just crash.