### PR TITLE
Fix the `tool.hdev.project_type` setting in `pyproject.toml`

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -149,10 +149,6 @@ score = "no"
 
 [tool.hdev]
 project_name = "{{ cookiecutter.name }}"
-{%- if cookiecutter._directory == "pyramid-app" %}
-project_type = "application"
-{%- elif cookiecutter._directory == "pypackage" %}
-project_type = "package"
-{%- endif %}
+project_type = "{{ cookiecutter.__hdev_project_type }}"
 
 {{- include("pyproject.toml") }}

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -17,6 +17,7 @@
     "__pypi_url": "https://pypi.org/project/{{ cookiecutter.slug }}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pypackage",
+    "__hdev_project_type": "library",
     "__ignore__": "",
     "__target_dir__": ""
 }

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -23,6 +23,7 @@
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pyramid-app",
+    "__hdev_project_type": "application",
     "__ignore__": "",
     "__target_dir__": ""
 }


### PR DESCRIPTION
Fix the `project_type` setting in the `[tool.hdev]` section in `pyproject.toml`: `hdev` uses `library` rather than `package` for packages (including both libraries like `h-vialib` and command line tools like `hdev` itself).

Also simplify this by making the `project_type` variable's value come from a `__hdev_project_type` setting in `cookiecutter.json`, which also means that it can be varied on a per-project basis.