### PR TITLE
Support Python 3.7 in packages by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+      - name: Install Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
       - run: python -m pip install cookiecutter tox
       - name: Configure git
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test sure: test-pypackage test-pyramid-app
 
 .PHONY: test-pypackage
 test-pypackage:
-	@bin/make_test pypackage python_versions="3.10.4, 3.9.12, 3.8.13" console_script=yes
+	@bin/make_test pypackage console_script=yes
 
 .PHONY: test-pyramid-app
 test-pyramid-app:

--- a/_shared/project/setup.cfg
+++ b/_shared/project/setup.cfg
@@ -20,6 +20,7 @@ packages = find:
 python_requires = >={{ python_versions()|oldest|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}
 {%- if include_exists("setuptools/install_requires") %}
 install_requires =
+    importlib_metadata;python_version<"3.8."
     {{- include("setuptools/install_requires", indent=4) }}
 {%- endif %}
 

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -3,7 +3,7 @@
     "package_name": "{{ cookiecutter.name.lower().replace(' ', '_').replace('-', '_') }}",
     "slug": "{{ cookiecutter.package_name.replace('_', '-') }}",
     "short_description": "An installable Python package.",
-    "python_versions": "3.10.4, 3.9.12, 3.8.13",
+    "python_versions": "3.10.4, 3.9.12, 3.8.13, 3.7.13",
     "github_owner": "hypothesis",
     "copyright_holder": "Hypothesis",
     "visibility": ["public", "private"],

--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
@@ -1,5 +1,9 @@
 from argparse import ArgumentParser
-from importlib.metadata import version
+
+try:
+    from importlib.metadata import version
+except ModuleNotFoundError:
+    from importlib_metadata import version
 
 
 def cli(_argv=None):  # pylint:disable=inconsistent-return-statements

--- a/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
@@ -1,8 +1,11 @@
-from importlib.metadata import version
-
 import pytest
 
 from {{ cookiecutter.package_name }}.cli import cli
+
+try:
+    from importlib.metadata import version
+except ModuleNotFoundError:
+    from importlib_metadata import version
 
 
 def test_it():


### PR DESCRIPTION
Add 3.7 to the list of Python versions supported by default when you create a new package using the pypackage cookiecutter. This means they support all four currently supported versions of Python by default.