### PR TITLE
Fix the `importlib_metadata` requirement

### DIFF
--- a/_shared/project/setup.cfg
+++ b/_shared/project/setup.cfg
@@ -18,11 +18,11 @@ package_dir =
     = src
 packages = find:
 python_requires = >={{ python_versions()|oldest|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}
-{%- if include_exists("setuptools/install_requires") %}
 install_requires =
     importlib_metadata;python_version<"3.8."
-    {{- include("setuptools/install_requires", indent=4) }}
-{%- endif %}
+    {%- if include_exists("setuptools/install_requires") %}
+      {{- include("setuptools/install_requires", indent=4) }}
+    {%- endif %}
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
The `importlib_metadata` requirement was only being listed in `setup.cfg` if the project had a
`.cookiecutter/includes/setuptools/install_requires` file, which projects don't have by default (the project only adds this file if it wants to add some custom install requirements to `setup.cfg`).

This bug should have caused the tests to fail: both this cookiecutter repo's `ci.yml` workflow and `make sure` command should have been failing, and also those of new packages generated by the cookiecutter. The reason why they were not failing is that `importlib-metadata` _was_ somehow still getting installed in the Python 3.7 tox environments even though it was missing from `setup.cfg`. My guess is that one of the test requirements from `tox.ini` (`pytest` etc) depends on `importlib-metadata`.

Fix it so that `importlib_metadata` is always listed in `setup.cfg`.