### PR TITLE
Fix outdated reference to `HACKING.md`

### DIFF
--- a/pyramid-app/README.md
+++ b/pyramid-app/README.md
@@ -30,7 +30,7 @@ Usage
    cookiecutter gh:hypothesis/cookiecutters --directory pyramid-app
    ```
 
-   See the `HACKING.md` file in your newly created project for instructions on
+   See the `README.md` file in your newly created project for instructions on
    managing the project.
 
 ### Updating a project


### PR DESCRIPTION
The stuff that was in `HACKING.md` got moved into `README.md`.
