### PR TITLE
Use the default Python version in the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ test-pypackage:
 
 .PHONY: test-pyramid-app
 test-pyramid-app:
-	@bin/make_test pyramid-app python_version=3.10.4 db=yes devdata=yes docker=yes frontend=yes services=yes
+	@bin/make_test pyramid-app db=yes devdata=yes docker=yes frontend=yes services=yes


### PR DESCRIPTION
If the tests don't specify a Python version then the default one from each cookiecutter's `cookiecutter.json` file will be used. This is good because it means the tests are testing that new projects created using the cookiecutters will work with the Python version(s) that the cookiecutters use by default.