### PR TITLE
Use Jinja2's `trim_blocks` and `lstrip_blocks`

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -123,7 +123,7 @@ def main():
 
         template_ignore_patterns = [".git/*"]
 
-        {%- if cookiecutter._directory == 'pyramid-app' %}
+        {% if cookiecutter._directory == 'pyramid-app' %}
         template_ignore_patterns.extend([
             "{{ cookiecutter.package_name }}/__init__.py",
             "{{ cookiecutter.package_name }}/app.py",
@@ -140,7 +140,7 @@ def main():
             "tests/functional/__init__.py",
             "tests/functional/app_test.py",
         ])
-        {%- else %}
+        {% else %}
         template_ignore_patterns.extend([
             "src/{{ cookiecutter.package_name }}/__init__.py",
             "src/{{ cookiecutter.package_name }}/__main__.py",
@@ -155,7 +155,7 @@ def main():
             "tests/functional/cli_test.py",
             "tests/functional/sanity_test.py",
         ])
-        {%- endif %}
+        {% endif %}
 
         for root, _dirs, files in walk(temp_dir):
             for file in files:
@@ -175,9 +175,9 @@ def main():
         # We're creating a new project for the first time.
         write_cookiecutter_json_file()
 
-        {% if cookiecutter._directory == 'pyramid-app' -%}
+        {% if cookiecutter._directory == 'pyramid-app' %}
         compile_requirements_files()
-        {%- endif %}
+        {% endif %}
 
         create_git_repo()
 

--- a/_shared/local_extensions.py
+++ b/_shared/local_extensions.py
@@ -1,3 +1,4 @@
+import textwrap
 from pathlib import Path
 
 from jinja2.ext import Extension, pass_context
@@ -109,9 +110,9 @@ class LocalJinja2Extension(Extension):
         try:
             lines = self._readlines(context, path)
         except (FileNotFoundError, NotADirectoryError):
-            lines = []
+            return ""
 
-        return "".join(["\n"] + [(" " * indent) + line for line in lines]).rstrip()
+        return textwrap.indent("".join(lines), " " * indent)
 
     def oldest(self, python_versions):
         """Return the oldest from `python_versions` by version number."""

--- a/_shared/project/.github/dependabot.yml
+++ b/_shared/project/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
-{%- if cookiecutter.get("frontend") == "yes" %}
+{% if cookiecutter.get("frontend") == "yes" %}
 - package-ecosystem: "npm"
   directory: "/"
   schedule:
@@ -15,8 +15,8 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
-{%- endif %}
-{%- if cookiecutter.get("docker") == "yes" %}
+{% endif %}
+{% if cookiecutter.get("docker") == "yes" %}
 - package-ecosystem: "docker"
   directory: "/"
   schedule:
@@ -28,4 +28,4 @@ updates:
     # Only send PRs for patch versions of Python.
     - dependency-name: "python"
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-{%- endif %}
+{% endif %}

--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -2,18 +2,18 @@ name: CI
 on:
   push:
   workflow_dispatch:
-  {%- if cookiecutter._directory == 'pypackage' %}
+  {% if cookiecutter._directory == 'pypackage' %}
   schedule:
   - cron: '0 1 * * *'
-  {%- endif %}
+  {% endif %}
 jobs:
-  {%- for job in ['format', 'lint', 'tests', 'coverage', 'functests'] %}
+  {% for job in ['format', 'lint', 'tests', 'coverage', 'functests'] %}
   {{ job|capitalize }}:
-    {%- if job == 'coverage' %}
+    {% if job == 'coverage' %}
     needs: tests
-    {%- endif %}
+    {% endif %}
     runs-on: ubuntu-latest
-    {%- if cookiecutter.get("db") == "yes" %}
+    {% if cookiecutter.get("db") == "yes" %}
     services:
       postgres:
         image: postgres:11.5-alpine
@@ -21,66 +21,65 @@ jobs:
         - 5432:5432
     env:
       TEST_DATABASE_URL: postgresql://postgres@localhost:5432/{{ cookiecutter.package_name }}_test
-    {%- endif %}
-    {%- if cookiecutter._directory == 'pypackage' and (job == 'tests' or job == 'functests') %}
+    {% endif %}
+    {% if cookiecutter._directory == 'pypackage' and (job == 'tests' or job == 'functests') %}
     strategy:
       matrix:
         python-version: [{{ python_versions()|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT)|quote("'") }}]
-    {%- endif %}
-    {%- if cookiecutter._directory == 'pypackage' and job == 'tests' %}
-    name: Unit tests with Python {% raw %}${{ matrix.python-version }}{% endraw %}
-    {%- elif cookiecutter._directory == 'pypackage' and job == 'functests' %}
-    name: Functional tests with Python {% raw %}${{ matrix.python-version }}{% endraw %}
-    {%- endif %}
+    {% endif %}
+    {% if cookiecutter._directory == 'pypackage' and job == 'tests' %}
+    name: Unit tests with Python {% raw %}${{ matrix.python-version }}{% endraw +%}
+    {% elif cookiecutter._directory == 'pypackage' and job == 'functests' %}
+    name: Functional tests with Python {% raw %}${{ matrix.python-version }}{% endraw +%}
+    {% endif %}
     steps:
       - uses: actions/checkout@v3
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          {%- if cookiecutter._directory == 'pypackage' and (job == 'tests' or job == 'functests') %}
-          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
-          {%- else %}
+          {% if cookiecutter._directory == 'pypackage' and (job == 'tests' or job == 'functests') %}
+          python-version: {% raw %}${{ matrix.python-version }}{% endraw +%}
+          {% else %}
           python-version: '{{ python_versions()|first|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}'
-          {%- endif %}
-
-      {%- if cookiecutter._directory == 'pyramid-app' %}
+          {% endif %}
+      {% if cookiecutter._directory == 'pyramid-app' %}
       - name: Cache the .tox dir
         uses: actions/cache@v3
         with:
           path: .tox
-          key: {{ job }}-{% raw %}${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}{% endraw %}
+          key: {{ job }}-{% raw %}${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}{% endraw +%}
           restore-keys: |
-            {{ job }}-{% raw %}${{ runner.os }}-tox-{% endraw %}
-      {%- endif %}
-      {%- if cookiecutter.get("db") == "yes" %}
+            {{ job }}-{% raw %}${{ runner.os }}-tox-{% endraw +%}
+      {% endif %}
+      {% if cookiecutter.get("db") == "yes" %}
       - name: Create test database
         run: psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE {{ cookiecutter.package_name }}_test'
-      {%- endif %}
-      {%- if cookiecutter.get("frontend") == "yes" %}
+      {% endif %}
+      {% if cookiecutter.get("frontend") == "yes" %}
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      {%- endif %}
-      {%- if job == 'coverage' %}
+      {% endif %}
+      {% if job == 'coverage' %}
       - name: Download coverage files
         uses: actions/download-artifact@v3
         with:
           name: coverage
-      {%- endif %}
+      {% endif %}
       - run: python -m pip install tox
-      {%- if job == 'format' %}
+      {% if job == 'format' %}
       - run: tox -e checkformatting
-      {%- else %}
+      {% else %}
       - run: tox -e {{ job }}
-      {%- endif %}
-      {%- if job == 'tests' %}
+      {% endif %}
+      {% if job == 'tests' %}
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: .coverage.*
-      {%- endif %}
-  {%- endfor %}
-  {%- if cookiecutter.get("frontend") == "yes" %}
+      {% endif %}
+  {% endfor %}
+  {% if cookiecutter.get("frontend") == "yes" %}
   Frontend:
     runs-on: ubuntu-latest
     steps:
@@ -90,7 +89,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: node_modules
-        key: {% raw %}${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}{% endraw %}
+        key: {% raw %}${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}{% endraw +%}
     - name: Install
       run: yarn install --frozen-lockfile
     - name: Format
@@ -99,5 +98,5 @@ jobs:
       run: make frontend-lint
     - name: Test
       run: make frontend-test
-  {%- endif %}
-  {{- include(".github/workflows/ci.yml", indent=2) }}
+  {% endif %}
+  {{- include(".github/workflows/ci.yml", indent=2) -}}

--- a/_shared/project/.python-version
+++ b/_shared/project/.python-version
@@ -1,3 +1,3 @@
-{% for python_version in python_versions() -%}
-  {{ python_version }}
-{% endfor -%}
+{% for python_version in python_versions() %}
+  {{- python_version }}
+{% endfor %}

--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -5,21 +5,20 @@ help = help::; @echo $$$$(tput bold)$(strip $(1)):$$$$(tput sgr0) $(strip $(2))
 $(call help,make help,print this help message)
 
 .PHONY: services
-{%- if cookiecutter.get("services") == "yes" %}
+{% if cookiecutter.get("services") == "yes" %}
 $(call help,make services,start the services that the app needs)
 services: args?=up -d
 services: python
 	@tox -qe dockercompose -- $(args)
-{%- endif %}
+{% endif %}
 
 .PHONY: devdata
-{%- if cookiecutter.get("devdata") == "yes" %}
+{% if cookiecutter.get("devdata") == "yes" %}
 $(call help,make devdata,load development data and environment variables)
 devdata: python
 	@tox -qe dev --run-command 'python bin/make_devdata'
-{%- endif %}
-
-{%- if cookiecutter.get("_directory") == "pyramid-app" %}
+{% endif %}
+{% if cookiecutter.get("_directory") == "pyramid-app" %}
 
 .PHONY: dev
 $(call help,make dev,run the whole app \(all workers\))
@@ -30,86 +29,81 @@ dev: python
 $(call help,make web,run just a web worker)
 web: python
 	@pyenv exec tox -qe dev --run-command 'gunicorn --bind :{{ cookiecutter.port }} --workers 1 --reload --timeout 0 --paste conf/development.ini'
-
-{%- endif %}
+{% endif %}
 
 .PHONY: shell
 $(call help,make shell,"launch a Python shell in this project's virtualenv")
 shell: python
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
 	@pyenv exec tox -qe dev --run-command 'pshell conf/development.ini'
-{%- else %}
+{% else %}
 	@pyenv exec tox -qe dev
-{%- endif %}
+{% endif %}
 
 .PHONY: lint
 $(call help,make lint,"lint the code and print any warnings")
 lint: python
 	@pyenv exec tox -qe lint
+{% if cookiecutter.get("frontend") == "yes" %}
 
-{% if cookiecutter.get("frontend") == "yes" -%}
 .PHONY: frontend-lint
 $(call help,make frontend-lint,"lint the frontend code")
 sure: frontend-lint
 frontend-lint:
 	@yarn lint
-	{%- if cookiecutter.get("__frontend_typechecking") == "yes" %}
+	{% if cookiecutter.get("__frontend_typechecking") == "yes" %}
 	@yarn typecheck
-	{%- endif %}
-
-{% endif -%}
+	{% endif %}
+{% endif %}
 
 .PHONY: format
 $(call help,make format,"format the code")
 format: python
 	@pyenv exec tox -qe format
+{% if cookiecutter.get("frontend") == "yes" %}
 
-{% if cookiecutter.get("frontend") == "yes" -%}
 .PHONY: frontend-format
 $(call help,make frontend-format,"format the frontend code")
 frontend-format:
 	@yarn format
-
-{% endif -%}
+{% endif %}
 
 .PHONY: checkformatting
 $(call help,make checkformatting,"crash if the code isn't correctly formatted")
 checkformatting: python
 	@pyenv exec tox -qe checkformatting
+{% if cookiecutter.get("frontend") == "yes" %}
 
-{% if cookiecutter.get("frontend") == "yes" -%}
 .PHONY: frontend-checkformatting
 sure: frontend-checkformatting
 $(call help,make frontend-checkformatting,"check the frontend code formatting")
 frontend-checkformatting:
 	@yarn checkformatting
-
-{% endif -%}
+{% endif %}
 
 .PHONY: test
 $(call help,make test,"run the unit tests in Python {{ python_versions()|first|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
 coverage: test
 test: python
 	@pyenv exec tox -qe tests
-
-{%- if cookiecutter.get("frontend") == "yes" %}
+{% if cookiecutter.get("frontend") == "yes" %}
 
 .PHONY: frontend-test
 sure: frontend-test
 $(call help,make frontend-test,"run the frontend tests")
 frontend-test:
 	@yarn test $(ARGS)
-{%- endif %}
+{% endif %}
 
-{%- for python_version in python_versions()|rest %}
+{% for python_version in python_versions()|rest %}
 {% set target = 'test-py%s'|format(python_version|pyformat(PyFormats.MAJOR_MINOR_FMT)) %}
 .PHONY: {{ target }}
 $(call help,make {{ target }},"run the unit tests in Python {{ python_version|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
 coverage: {{ target }}
 {{ target }}: python
 	@pyenv exec tox -qe py{{ python_version|pyformat(PyFormats.MAJOR_MINOR_FMT) }}-tests
-{%- endfor %}
 
+{% endfor %}
 .PHONY: coverage
 $(call help,make coverage,"run the tests and print the coverage report")
 coverage: python
@@ -120,25 +114,25 @@ $(call help,make functests,"run the functional tests in Python {{ python_version
 functests: python
 	@pyenv exec tox -qe functests
 
-{%- for python_version in python_versions()|rest %}
+{% for python_version in python_versions()|rest %}
 {% set target = 'functests-py%s'|format(python_version|pyformat(PyFormats.MAJOR_MINOR_FMT)) %}
 .PHONY: {{ target }}
 $(call help,make {{ target }},"run the functional tests in Python {{ python_version|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
 {{ target }}: python
 	@pyenv exec tox -qe py{{ python_version|pyformat(PyFormats.MAJOR_MINOR_FMT) }}-functests
-{%- endfor %}
 
+{% endfor %}
 .PHONY: sure
 $(call help,make sure,"make sure that the formatting$(comma) linting and tests all pass")
 sure: python
 sure:
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
 	@pyenv exec tox --parallel -qe 'checkformatting,lint,tests,coverage,functests'
-{%- else %}
+{% else %}
 	@pyenv exec tox --parallel -qe 'checkformatting,lint,tests,py{{ "{" }}{{ python_versions()|rest|pyformat(PyFormats.MAJOR_MINOR_FMT)|separator(",") }}{{ "}" }}-tests,coverage,functests,py{{ "{" }}{{ python_versions()|rest|pyformat(PyFormats.MAJOR_MINOR_FMT)|separator(",") }}{{ "}" }}-functests'
-{%- endif %}
+{% endif %}
 
-{% if cookiecutter._directory == 'pyramid-app' -%}
+{% if cookiecutter._directory == 'pyramid-app' %}
 # Tell make how to compile requirements/*.txt files.
 #
 # `touch` is used to pre-create an empty requirements/%.txt file if none
@@ -177,14 +171,13 @@ requirements/lint.txt: requirements/tests.txt requirements/functests.txt
 $(call help,make requirements,"compile the requirements files")
 requirements requirements/: $(foreach file,$(wildcard requirements/*.in),$(basename $(file)).txt)
 
-{% endif -%}
-
+{% endif %}
 .PHONY: template
 $(call help,make template,"update from the latest cookiecutter template")
 template: python
 	@pyenv exec tox -e template -- $$(if [ -n "$${template+x}" ]; then echo "--template $$template"; fi) $$(if [ -n "$${checkout+x}" ]; then echo "--checkout $$checkout"; fi) $$(if [ -n "$${directory+x}" ]; then echo "--directory $$directory"; fi)
 
-{% if cookiecutter.get("docker") == "yes" -%}
+{% if cookiecutter.get("docker") == "yes" %}
 DOCKER_TAG = dev
 
 .PHONY: docker
@@ -197,9 +190,9 @@ $(call help,make docker-run,"run the app's docker image")
 docker-run:
 	@docker run \
 		--add-host host.docker.internal:host-gateway \
-{%- if cookiecutter.get("services") == "yes" %}
+{% if cookiecutter.get("services") == "yes" %}
 		--net {{ cookiecutter.__docker_network }} \
-{%- endif %}
+{% endif %}
 		--env-file .docker.env \
 {%- if cookiecutter.get("devdata") == "yes" %}
 		--env-file .devdata.env \
@@ -207,17 +200,18 @@ docker-run:
 		-p {{ cookiecutter.port }}:{{ cookiecutter.port }} \
 		{{ cookiecutter.__docker_namespace }}/{{ cookiecutter.slug }}:$(DOCKER_TAG)
 
-{% endif -%}
-
+{% endif %}
 .PHONY: clean
 $(call help,make clean,"delete temporary files etc")
 clean:
 	@rm -rf build dist .tox
 	@find . -path '*/__pycache__*' -delete
 	@find . -path '*.egg-info*' -delete
-{{- include("make_clean") }}
+{% if include_exists("make_clean") %}
+	{{- include("make_clean") -}}
+{% endif %}
 
-{% if cookiecutter.get("frontend") == "yes" -%}
+{% if cookiecutter.get("frontend") == "yes" %}
 dev: build/manifest.json
 devdata: build/manifest.json
 shell: build/manifest.json
@@ -235,8 +229,7 @@ node_modules/.uptodate: package.json yarn.lock
 	@yarn install
 	@touch $@
 
-{% endif -%}
-
+{% endif %}
 .PHONY: python
 python:
 	@bin/make_python

--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -1,19 +1,20 @@
-{% if cookiecutter._directory == 'pypackage' -%}
+{% if cookiecutter._directory == 'pypackage' %}
 [build-system]
 requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 
-{% endif -%}
-
+{% endif %}
 [tool.pytest.ini_options]
 addopts = "-q"
 filterwarnings = [
     "error", # Fail the tests if there are any warnings.
     "ignore:^find_module\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
     "ignore:^FileFinder.find_loader\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
-    {{- include("pytest/filterwarnings", indent=4) }}
+    {% if include_exists("pytest/filterwarnings") %}
+        {{- include("pytest/filterwarnings", indent=4) -}}
+    {% endif %}
 ]
 
 [tool.pydocstyle]
@@ -41,8 +42,10 @@ ignore = [
     # > https://peps.python.org/pep-0257/#multi-line-docstrings
     "D212",
     "D213",
+{% if include_exists("pydocstyle/ignores") %}
 
-    {{- include("pydocstyle/ignores", indent=4) }}
+{{ include("pydocstyle/ignores", indent=4) -}}
+{% endif %}
 ]
 
 [tool.coverage.run]
@@ -51,9 +54,9 @@ parallel = true
 source = ["{{ cookiecutter.package_name }}", "tests/unit"]
 omit = [
     "*/{{ cookiecutter.package_name }}/__main__.py",
-    {%- if include_exists("coverage/omit") %}
-    {{- include("coverage/omit", indent=4) }}
-    {%- endif %}
+    {% if include_exists("coverage/omit") %}
+        {{- include("coverage/omit", indent=4) -}}
+    {% endif %}
 ]
 
 [tool.coverage.paths]
@@ -86,7 +89,9 @@ load-plugins = [
     "pylint.extensions.mccabe",
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.redefined_variable_type",
-    {{- include("pylint/plugins", indent=4) }}
+    {% if include_exists("pylint/plugins") %}
+        {{- include("pylint/plugins", indent=4) -}}
+    {% endif %}
 ]
 
 # Fail if there are *any* messages from PyLint.
@@ -100,7 +105,9 @@ enable = [
     "deprecated-pragma",
     "useless-suppression",
     "use-symbolic-message-instead",
-    {{- include("pylint/enables", indent=4) }}
+    {% if include_exists("pylint/enables") %}
+        {{- include("pylint/enables", indent=4) -}}
+    {% endif %}
 ]
 disable = [
     # Docstrings are encouraged but we don't want to enforce that everything
@@ -133,14 +140,18 @@ disable = [
 
     # Issues to disable this for false positives, disabling it globally in the meantime https://github.com/PyCQA/pylint/issues/214
     "duplicate-code",
+{% if include_exists("pylint/disables") %}
 
-    {{- include("pylint/disables", indent=4) }}
+{{ include("pylint/disables", indent=4) -}}
+{% endif %}
 ]
 
 good-names = [
     "i", "j", "k", "ex", "Run", "_", # PyLint's default good names.
     "tm", "db", "ai",
-    {{- include("pylint/good_names", indent=4) }}
+    {% if include_exists("pylint/good_names") %}
+        {{- include("pylint/good_names", indent=4) -}}
+    {% endif %}
 ]
 
 [tool.pylint.reports]
@@ -150,5 +161,7 @@ score = "no"
 [tool.hdev]
 project_name = "{{ cookiecutter.name }}"
 project_type = "{{ cookiecutter.__hdev_project_type }}"
+{% if include_exists("pyproject.toml") %}
 
-{{- include("pyproject.toml") }}
+{{ include("pyproject.toml") -}}
+{% endif %}

--- a/_shared/project/setup.cfg
+++ b/_shared/project/setup.cfg
@@ -1,4 +1,4 @@
-{% if cookiecutter._directory == 'pypackage' -%}
+{% if cookiecutter._directory == 'pypackage' %}
 [metadata]
 name = {{ cookiecutter.slug }}
 description = {{ cookiecutter.short_description }}
@@ -20,25 +20,26 @@ packages = find:
 python_requires = >={{ python_versions()|oldest|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}
 install_requires =
     importlib_metadata;python_version<"3.8."
-    {%- if include_exists("setuptools/install_requires") %}
-      {{- include("setuptools/install_requires", indent=4) }}
-    {%- endif %}
+{% if include_exists("setuptools/install_requires") %}
+  {{- include("setuptools/install_requires", indent=4) -}}
+{% endif %}
 
 [options.packages.find]
 where = src
 
 [options.entry_points]
-{%- if include_exists("setuptools/console_scripts") %}
+{% if include_exists("setuptools/console_scripts") %}
 console_scripts =
-    {{- include("setuptools/console_scripts", indent=4) }}
-{%- elif cookiecutter.get("console_script") == "yes" %}
+{{ include("setuptools/console_scripts", indent=4) -}}
+{% elif cookiecutter.get("console_script") == "yes" %}
 console_scripts =
     {{ cookiecutter.__entry_point }} = {{ cookiecutter.package_name }}.cli:cli
-{%- endif %}
-{{- include("setuptools/entry_points") }}
+{% endif %}
+{% if include_exists("setuptools/entry_points") %}
+    {{- include("setuptools/entry_points") -}}
+{% endif %}
 
-{% endif -%}
-
+{% endif %}
 [pycodestyle]
 ignore =
     # Disable pycodestyle errors and warnings that we don't care about because
@@ -54,7 +55,11 @@ ignore =
 
     # Bare except. PyLint finds these for us so we don't need pycodestyle to.
     E722,
+{% if include_exists("pycodestyle/ignores") %}
 
-    {{- include("pycodestyle/ignores", indent=4) }}
+    {{- include("pycodestyle/ignores", indent=4) -}}
+{% endif %}
+{% if include_exists("setup.cfg") %}
 
-{{- include("setup.cfg") }}
+{{ include("setup.cfg") -}}
+{% endif %}

--- a/_shared/project/tests/pyproject.toml
+++ b/_shared/project/tests/pyproject.toml
@@ -10,7 +10,9 @@ load-plugins = [
     "pylint.extensions.mccabe",
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.redefined_variable_type",
-    {{- include("tests/pylint/plugins", indent=4) }}
+    {% if include_exists("tests/pylint/plugins") %}
+        {{- include("tests/pylint/plugins", indent=4) -}}
+    {% endif %}
 ]
 
 # Fail if there are *any* messages from PyLint.
@@ -20,14 +22,18 @@ fail-on = ["C", "E", "F", "I", "R", "W"]
 
 [tool.pylint.messages_control]
 ignore-paths = [
-    {{- include("tests/pylint/ignore-paths", indent=4) }}
+    {% if include_exists("tests/pylint/ignore-paths") %}
+        {{- include("tests/pylint/ignore-paths", indent=4) -}}
+    {% endif %}
 ]
 enable = [
     "bad-inline-option",
     "deprecated-pragma",
     "useless-suppression",
     "use-symbolic-message-instead",
-    {{- include("tests/pylint/enables", indent=4) }}
+    {% if include_exists("tests/pylint/enables") %}
+        {{- include("tests/pylint/enables", indent=4) -}}
+    {% endif %}
 ]
 disable = [
     # Docstrings are encouraged but we don't want to enforce that everything
@@ -71,8 +77,10 @@ disable = [
 
     # Issues to disable this for false positives, disabling it globally in the meantime https://github.com/PyCQA/pylint/issues/214
     "duplicate-code",
+{% if include_exists("tests/pylint/disables") %}
 
-    {{- include("tests/pylint/disables", indent=4) }}
+{{ include("tests/pylint/disables", indent=4) -}}
+{% endif %}
 ]
 
 # Just disable PyLint's name style checking for the tests, because we
@@ -90,7 +98,9 @@ good-names = [
     "i", "j", "k", "ex", "Run", "_", # PyLint's default good names.
     "pytestmark",
     "os", # Name used for mocks of the standard os module.
-    {{- include("tests/pylint/good_names", indent=4) }}
+    {% if include_exists("tests/pylint/good_names") %}
+        {{- include("tests/pylint/good_names", indent=4) -}}
+    {% endif %}
 ]
 
 [tool.pylint.reports]

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -1,47 +1,51 @@
 [tox]
 envlist = tests
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
 skipsdist = true
-{%- endif %}
+{% endif %}
 minversion = 3.25.0
 requires =
     tox-envfile
     tox-faster
     tox-run-command
-    {%- if cookiecutter._directory == 'pypackage' %}
+    {% if cookiecutter._directory == 'pypackage' %}
     tox-recreate
-    {%- endif %}
-{%- if cookiecutter._directory == 'pypackage' %}
+    {% endif %}
+{% if cookiecutter._directory == 'pypackage' %}
 isolated_build = true
-{%- endif %}
+{% endif %}
 
 [testenv]
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
 skip_install = true
-{%- else %}
+{% else %}
 skip_install =
     format,checkformatting,coverage,template: true
-{%- endif %}
+{% endif %}
 setenv =
     PYTHONUNBUFFERED = 1
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
     # Make `import {{ cookiecutter.package_name }}` work in `make shell`.
     dev: PYTHONPATH = .
-{%- endif %}
-    {{- include("tox/setenv", indent=4) }}
+{% endif %}
+    {% if include_exists("tox/setenv") %}
+        {{- include("tox/setenv", indent=4) -}}
+    {% endif %}
 passenv =
     HOME
     PYTEST_ADDOPTS
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
     GUNICORN_CERTFILE
     GUNICORN_KEYFILE
-{%- endif %}
-    {{- include("tox/passenv", indent=4) }}
+{% endif %}
+    {% if include_exists("tox/passenv") %}
+        {{- include("tox/passenv", indent=4) -}}
+    {% endif %}
 deps =
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
     pip-tools
-{%- elif cookiecutter._directory == 'pypackage' %}
+{% elif cookiecutter._directory == 'pypackage' %}
     dev: ipython
     format,checkformatting: black
     format,checkformatting: isort
@@ -55,26 +59,31 @@ deps =
     lint,tests,functests: factory-boy
     lint,tests,functests: h-matchers
     lint,template: cookiecutter
-{%- endif %}
-    {{- include("tox/deps", indent=4) }}
+{% endif %}
+    {% if include_exists("tox/deps") %}
+        {{- include("tox/deps", indent=4) -}}
+    {% endif %}
 depends =
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
     coverage: tests
-{%- else %}
+{% else %}
     coverage: tests,py{{ "{" }}{{ python_versions()|rest|pyformat(PyFormats.MAJOR_MINOR_FMT)|separator(",") }}{{ "}" }}-tests
-{%- endif %}
-
-{%- if include_exists("tox/allowlist_externals") %}
+{% endif %}
+{% if include_exists("tox/allowlist_externals") %}
 allowlist_externals = 
-    {{- include("tox/allowlist_externals", indent=4) }}
-{%- endif %}
-{%- if cookiecutter._directory == 'pyramid-app' %}
+    {{- include("tox/allowlist_externals", indent=4) -}}
+{% endif %}
+{% if cookiecutter._directory == 'pyramid-app' or include_exists("tox/commands_pre") %}
 commands_pre =
+    {% if cookiecutter._directory == 'pyramid-app' %}
     pip-sync requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
-    {{- include("tox/commands_pre", indent=4) }}
-{%- endif %}
+    {% endif %}
+    {% if include_exists("tox/commands_pre") %}
+        {{- include("tox/commands_pre", indent=4) -}}
+    {% endif %}
+{% endif %}
 commands =
-{%- if cookiecutter._directory == 'pyramid-app' %}
+{% if cookiecutter._directory == 'pyramid-app' %}
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     format: black {{ cookiecutter.package_name }} tests bin
     format: isort --atomic {{ cookiecutter.package_name }} tests bin
@@ -85,7 +94,7 @@ commands =
     lint: pydocstyle {{ cookiecutter.package_name }} tests bin
     lint: pycodestyle {{ cookiecutter.package_name }} tests bin
     dockercompose: docker-compose {posargs}
-{%- else %}
+{% else %}
     dev: {posargs:ipython --classic --no-banner --no-confirm-exit}
     format: black src tests bin
     format: isort --atomic src tests bin
@@ -95,15 +104,16 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle src tests bin
     lint: pycodestyle src tests bin
-{%- endif %}
+{% endif %}
     tests: coverage run -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
     functests: pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: -coverage combine
     coverage: coverage report
     template: python3 bin/make_template {posargs}
-    {{- include("tox/commands", indent=4) }}
-
-{%- if cookiecutter._directory == 'pyramid-app' %}
+    {% if include_exists("tox/commands") %}
+        {{- include("tox/commands", indent=4) -}}
+    {% endif %}
+{% if cookiecutter._directory == 'pyramid-app' %}
 
 [testenv:dev]
 # By default when you Ctrl-c the `make dev` command tox is too aggressive about
@@ -117,4 +127,4 @@ commands =
 suicide_timeout = 60.0
 interrupt_timeout = 60.0
 terminate_timeout = 60.0
-{%- endif %}
+{% endif %}

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -19,5 +19,6 @@
     "_directory": "pypackage",
     "__hdev_project_type": "library",
     "__ignore__": "",
-    "__target_dir__": ""
+    "__target_dir__": "",
+    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
 }

--- a/pypackage/{{ cookiecutter.slug }}/README.md
+++ b/pypackage/{{ cookiecutter.slug }}/README.md
@@ -1,6 +1,6 @@
-{% if cookiecutter.get("visibility") == "public" -%}
+{% if cookiecutter.get("visibility") == "public" %}
 <a href="{{ cookiecutter.__github_url }}/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/workflow/status/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}/CI/main"></a>
-{% endif -%}
+{% endif %}
 <a href="{{ cookiecutter.__pypi_url }}"><img src="https://img.shields.io/pypi/v/{{ cookiecutter.slug }}"></a>
 <a><img src="https://img.shields.io/badge/python-{{ python_versions()|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT)|separator(" | ") }}-success"></a>
 <a href="{{ cookiecutter.__github_url }}/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSD--2--Clause-success"></a>
@@ -10,11 +10,12 @@
 # {{ cookiecutter.name }}
 
 {{ cookiecutter.short_description }}
+{% if include_exists("README/head.md") %}
 
-{{- include("README/head.md") }}
+{{ include("README/head.md") -}}
+{% endif %}
 
-{%- if cookiecutter.get("console_script") == "yes" %}
-
+{% if cookiecutter.get("console_script") == "yes" %}
 ## Installing
 
 We recommend using [pipx](https://pypa.github.io/pipx/) to install
@@ -52,8 +53,8 @@ To uninstall run:
 ```
 pipx uninstall {{ cookiecutter.slug }}
 ```
-{%- endif %}
 
+{% endif %}
 ## Setting up Your {{ cookiecutter.name }} Development Environment
 
 First you'll need to install:
@@ -68,7 +69,9 @@ First you'll need to install:
   The **Basic GitHub Checkout** method works best on Ubuntu.
   You _don't_ need to set up pyenv's shell integration ("shims"), you can
   [use pyenv without shims](https://github.com/pyenv/pyenv#using-pyenv-without-shims).
-{{- include("hacking/prerequisites") }}
+{% if include_exists("hacking/prerequisites") %}
+    {{- include("hacking/prerequisites") -}}
+{% endif %}
 
 Then to set up your development environment:
 
@@ -154,5 +157,7 @@ To change the project's formatting, linting and test dependencies:
    ```
 
 3. Commit everything to git and send a pull request
+{% if include_exists("README/tail.md") %}
 
-{{- include("README/tail.md") }}
+{{ include("README/tail.md") -}}
+{% endif %}

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -25,5 +25,6 @@
     "_directory": "pyramid-app",
     "__hdev_project_type": "application",
     "__ignore__": "",
-    "__target_dir__": ""
+    "__target_dir__": "",
+    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
 }

--- a/pyramid-app/{{ cookiecutter.slug }}/README.md
+++ b/pyramid-app/{{ cookiecutter.slug }}/README.md
@@ -1,6 +1,6 @@
-{% if cookiecutter.get("visibility") == "public" -%}
+{% if cookiecutter.get("visibility") == "public" %}
 <a href="{{ cookiecutter.__github_url }}/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/workflow/status/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}/CI/main"></a>
-{% endif -%}
+{% endif %}
 <a><img src="https://img.shields.io/badge/python-{{ python_versions()|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT)|separator(" | ") }}-success"></a>
 <a href="{{ cookiecutter.__github_url }}/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSD--2--Clause-success"></a>
 <a href="https://github.com/hypothesis/cookiecutters/tree/main/pyramid-app"><img src="https://img.shields.io/badge/cookiecutter-pyramid--app-success"></a>
@@ -25,7 +25,7 @@ First you'll need to install:
   [use pyenv without shims](https://github.com/pyenv/pyenv#using-pyenv-without-shims).
 * [GNU Make](https://www.gnu.org/software/make/).
   This is probably already installed or will have been installed while installing pyenv, run `make --version` to check.
-{%- if cookiecutter.get("services") == "yes" %}
+{% if cookiecutter.get("services") == "yes" %}
 * [Docker](https://docs.docker.com/install/).
   Follow the [instructions on the Docker website](https://docs.docker.com/install/)
   to install it.  
@@ -33,14 +33,16 @@ First you'll need to install:
   will install it automatically for you in tox.  
   You **do** need to set up the `docker` command to work without `sudo`,
   on Linux this means following Docker's [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/).
-{%- endif %}
-{%- if cookiecutter.get("frontend") == "yes" %}
+{% endif %}
+{% if cookiecutter.get("frontend") == "yes" %}
 * [Node](https://nodejs.org/) and npm.
   On Ubuntu: `sudo snap install --classic node`.
   On macOS: `brew install node`.
 * [Yarn](https://yarnpkg.com/): `sudo npm install -g yarn`.
-{%- endif %}
-{{- include("hacking/prerequisites") }}
+{% endif %}
+{% if include_exists("hacking/prerequisites") %}
+    {{- include("hacking/prerequisites") -}}
+{% endif %}
 
 Then to set up your development environment:
 

--- a/pyramid-app/{{ cookiecutter.slug }}/conf/development.ini
+++ b/pyramid-app/{{ cookiecutter.slug }}/conf/development.ini
@@ -1,8 +1,10 @@
 [app:main]
 use = call:{{ cookiecutter.package_name }}.app:create_app
 debug = true
+{% if include_exists("development.ini") %}
 
-{{- include("development.ini") }}
+{{ include("development.ini") -}}
+{% endif %}
 
 [pshell]
 setup = {{ cookiecutter.package_name }}.pshell.setup

--- a/pyramid-app/{{ cookiecutter.slug }}/conf/supervisord-dev.conf
+++ b/pyramid-app/{{ cookiecutter.slug }}/conf/supervisord-dev.conf
@@ -8,8 +8,10 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
+{% if include_exists("conf/supervisord-dev.conf") %}
 
-{{- include("conf/supervisord-dev.conf") }}
+{{ include("conf/supervisord-dev.conf") -}}
+{% endif %}
 
 [eventlistener:logger]
 command=bin/logger --dev

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/checkformatting.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/checkformatting.in
@@ -1,4 +1,6 @@
 pip-tools
 black
 isort
-{{- include("requirements/checkformatting.in") }}
+{% if include_exists("requirements/checkformatting.in") %}
+    {{- include("requirements/checkformatting.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/coverage.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/coverage.in
@@ -1,3 +1,5 @@
 pip-tools
 coverage[toml]
-{{- include("requirements/coverage.in") }}
+{% if include_exists("requirements/coverage.in") %}
+    {{- include("requirements/coverage.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/dev.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/dev.in
@@ -3,4 +3,6 @@ pip-tools
 factory-boy
 pyramid-ipython
 supervisor
-{{- include("requirements/dev.in") }}
+{% if include_exists("requirements/dev.in") %}
+    {{- include("requirements/dev.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/format.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/format.in
@@ -1,4 +1,6 @@
 pip-tools
 black
 isort
-{{- include("requirements/format.in") }}
+{% if include_exists("requirements/format.in") %}
+    {{- include("requirements/format.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/functests.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/functests.in
@@ -5,4 +5,6 @@ pytest
 factory-boy
 h-matchers
 webtest
-{{- include("requirements/functests.in") }}
+{% if include_exists("requirements/functests.in") %}
+    {{- include("requirements/functests.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/lint.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/lint.in
@@ -5,4 +5,6 @@ toml # Needed for pydocstyle to support pyproject.toml.
 pylint
 pydocstyle
 pycodestyle
-{{- include("requirements/lint.in") }}
+{% if include_exists("requirements/lint.in") %}
+    {{- include("requirements/lint.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/prod.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/prod.in
@@ -1,4 +1,6 @@
 pyramid
 gunicorn
 newrelic
-{{- include("requirements/prod.in") }}
+{% if include_exists("requirements/prod.in") %}
+    {{- include("requirements/prod.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/template.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/template.in
@@ -1,3 +1,5 @@
 pip-tools
 cookiecutter
-{{- include("requirements/template.in") }}
+{% if include_exists("requirements/template.in") %}
+    {{- include("requirements/template.in") -}}
+{% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/requirements/tests.in
+++ b/pyramid-app/{{ cookiecutter.slug }}/requirements/tests.in
@@ -6,4 +6,6 @@ factory-boy
 h-matchers
 httpretty
 freezegun
-{{- include("requirements/tests.in") }}
+{% if include_exists("requirements/tests.in") %}
+    {{- include("requirements/tests.in") -}}
+{% endif %}


### PR DESCRIPTION
This makes Jinja2 automatically remove whitespace around template tags meaning much less manual whitespace management is needed. When using `{% if %}`'s etc it generally just does what we want 99% of the time and 1% of the time we have to use explicit whitespace control, rather than the other way around.

I also made a change to our custom `include()` function. Previously you used to be able to just do this:

```jinja2
{{- include("foo/bar") }}
```

and that would render the contents of the project's `.cookiecutter/includes/foo/bar` file if it exists or would render nothing (not even a blank line) if the include file doesn't exist.

This is not normal Jinja2 behaviour. To get this to work the `include()` Python code would prepend a `"\n"` to the text from the include file and would also strip any trailing whitespace (including the `"\n"` at the end of the last line of the file). So it'd remove the `"\n"` from the end of the file and prepend a `"\n"` to the beginning!

It didn't actually work either. In many cases it would remove any blank lines that were above the `include()` in the template. So if you wanted to have a blank line before the contents of an include file the template couldn't do that. You had to actually put a blank line at the top of the include file in every project.

This hack no longer works at all with `trim_blocks` and `lstrip_blocks`: the output gets messed up any time you try to use an include.

Also having `include()` mess with newlines like this is a really bad idea because it's so unexpected and confusing. I forgot that I had done it, and it took me ages wondering why the flip whitespace control was going nuts before I finally realised that our custom Python code was doing this.

I've simplified `include()` to not do anything unexpected: it neither prepends a leading `"\n"` nor strips a trailing one.

This does make the templates a bit more wordy as they frequently have to do variations on this pattern:

```jinja2
{% if include_exists("foo/bar") %}
    {{ include("foo/bar") }}
{% endif %}
```

But at least this is comprehensible. It lets the template freely use Jinja2's whitespace control go get whatever whitespace behaviour you want (`-` or no `-`, leading or trailing blank lines in the template or not, etc). It gives the same whitespace behaviour as you'd get with other conditional blocks like:

```jinja2
{% if cookiecutter.get("services") %}
.PHONY: services
services: args?=up -d
services: python
	@tox -qe dockercompose -- $(args)
{% endif %}
```

I also changed `include()` to use the stdlib's `indent()` instead of implementing its own indent code.