### PR TITLE
Fix `make docker-run` when there are services

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -197,9 +197,6 @@ $(call help,make docker-run,"run the app's docker image")
 docker-run:
 	@docker run \
 		--add-host host.docker.internal:host-gateway \
-{%- if cookiecutter.get("services") == "yes" %}
-		--net {{ cookiecutter.__docker_network }} \
-{%- endif %}
 		--env-file .docker.env \
 		--env-file .devdata.env \
 		-p {{ cookiecutter.port }}:{{ cookiecutter.port }} \


### PR DESCRIPTION
The `--net` argument to `docker run` (which is only used when `"services": "yes"` is in `cookiecutter.json`) doesn't seem to work:

```console
$ cd /tmp
$ cookiecutter gh:hypothesis/cookiecutters --directory pyramid-app --no-input docker=yes services=yes
$ cd my-pyramid-app
$ make services
$ make docker
$ # Work around https://github.com/hypothesis/cookiecutters/pull/83 by creating .devdata.env
$ touch .devdata.env
$ make docker-run
$ docker: Error response from daemon: network my_pyramid_app_default not found.
```

I'm not sure if this is the right fix (does this break the Docker container's access to the services?) but this commit removes the `--net` argument which at least gets the `make docker-run` command working again.
