### PR TITLE
Fix broken `cd` command in `README.md`

### DIFF
--- a/pypackage/{{ cookiecutter.slug }}/README.md
+++ b/pypackage/{{ cookiecutter.slug }}/README.md
@@ -74,7 +74,7 @@ Then to set up your development environment:
 
 ```terminal
 git clone {{ cookiecutter.__github_url }}.git
-cd {{ cookiecutter.package_name }}
+cd {{ cookiecutter.slug }}
 make help
 ```
 

--- a/pyramid-app/{{ cookiecutter.slug }}/README.md
+++ b/pyramid-app/{{ cookiecutter.slug }}/README.md
@@ -46,7 +46,7 @@ Then to set up your development environment:
 
 ```terminal
 git clone {{ cookiecutter.__github_url }}.git
-cd {{ cookiecutter.package_name }}
+cd {{ cookiecutter.slug }}
 make services
 make devdata
 make help


### PR DESCRIPTION
The `cd` command in the `README.md` template is broken when the project slug contains `-`'s. For example in [h-matchers](https://github.com/hypothesis/h-matchers):

```console
$ git clone https://github.com/hypothesis/h-matchers.git
$ cd h_matchers
cd: The directory “h_matchers” does not exist
```

Fix it to use `cookiecutter.slug` (`h-matchers`) instead of `cookiecutter.package_name` (`h_matchers`).