### PR TITLE
Speed up `make coverage` by using tox's parallelism

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -88,7 +88,6 @@ frontend-checkformatting:
 
 .PHONY: test
 $(call help,make test,"run the unit tests in Python {{ python_versions()|first|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
-coverage: test
 test: python
 	@pyenv exec tox -qe tests
 
@@ -105,7 +104,6 @@ frontend-test:
 {% set target = 'test-py%s'|format(python_version|pyformat(PyFormats.MAJOR_MINOR_FMT)) %}
 .PHONY: {{ target }}
 $(call help,make {{ target }},"run the unit tests in Python {{ python_version|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
-coverage: {{ target }}
 {{ target }}: python
 	@pyenv exec tox -qe py{{ python_version|pyformat(PyFormats.MAJOR_MINOR_FMT) }}-tests
 {%- endfor %}
@@ -113,7 +111,11 @@ coverage: {{ target }}
 .PHONY: coverage
 $(call help,make coverage,"run the tests and print the coverage report")
 coverage: python
-	@pyenv exec tox -qe coverage
+{%- if cookiecutter._directory == 'pyramid-app' %}
+	@pyenv exec tox -qe 'tests,coverage'
+{%- else %}
+	@pyenv exec tox --parallel -qe 'tests,py{{ "{" }}{{ python_versions()|rest|pyformat(PyFormats.MAJOR_MINOR_FMT)|separator(",") }}{{ "}" }}-tests,coverage'
+{%- endif %}
 
 .PHONY: functests
 $(call help,make functests,"run the functional tests in Python {{ python_versions()|first|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")


### PR DESCRIPTION
`make coverage` currently runs the unit tests for all Python versions in serial and then runs the coverage report. Speed it up by having it run the unit tests in parallel instead, then the coverage report. This is the same as how `make sure` already works.

**Scope:** this PR just speeds up `make coverage` by making it run tests in parallel rather than serial. It doesn't change what `make coverage` actually does. In particular: `make coverage` always runs all the tests before printing the coverage report. It might be better if it only ran the tests if they need to be run (if the code has changed since the last time the tests for each Python version were run and generated coverage data) but getting it to do that is a more vexxed problem than it may seem and anyway :man_shrugging: Note that if you just want to run the coverage report and not the tests you can do `tox -e coverage`. Anyway, out of scope here.