### PR TITLE
Fix whitespace around `.gitignore` include

### DIFF
--- a/_shared/project/.gitignore
+++ b/_shared/project/.gitignore
@@ -10,4 +10,6 @@ supervisord.log
 supervisord.pid
 .DS_Store
 .devdata.env
-{{- include("gitignore") }}
+{% if include_exists("gitignore") %}
+  {{- include("gitignore") -}}
+{% endif %}


### PR DESCRIPTION
This was adding an extra blank line before the contents of the `.cookiecutter/includes/gitignore` file. Fix it to work the same way as the rest of the includes do