### PR TITLE
Fix the `supervisorctl` prompt in dev

### DIFF
--- a/pyramid-app/{{ cookiecutter.slug }}/conf/supervisord-dev.conf
+++ b/pyramid-app/{{ cookiecutter.slug }}/conf/supervisord-dev.conf
@@ -29,4 +29,4 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
 serverurl = unix://.supervisor.sock
-prompt = {{ cookiecutter.package_name }}
+prompt = {{ cookiecutter.slug }}


### PR DESCRIPTION
It's a small thing but the prompt should be `h-periodic>` not `h_periodic>`.

The prompt that is being changed here is the [supervisorctl](http://supervisord.org/running.html#running-supervisorctl) prompt that lets you start/restart/inspect the app's processes. You get to this prompt by running:

```bash
tox -e dev --run-command 'supervisorctl -c conf/supervisord-dev.conf'
```

Some of our apps have a `make supervisor` command that's an alias for the above. But since I don't think anyone ever uses `make supervisor` the cookiecutter doesn't have it.