### PR TITLE
Omit `_jinja2_env_vars` from `cookiecutter.json`

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -54,6 +54,7 @@ def write_cookiecutter_json_file():
     del extra_context["_extensions"]
     del extra_context["_template"]
     del extra_context["_output_dir"]
+    del extra_context["_jinja2_env_vars"]
     if "__target_dir__" in extra_context:
         del extra_context["__target_dir__"]
     if "__ignore__" in extra_context:


### PR DESCRIPTION
This just prevents `"_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}` from ending up in the `cookiecutter.json` files of generated projects.

We don't want these settings getting into projects' `cookiecutter.json` files. If any project ever changed these settings in `cookiecutter.json` it'd just completely break all the templates.