### PR TITLE
Make `ci.yml` callable by other workflows

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
   workflow_dispatch:
+  workflow_call:
   {% if cookiecutter._directory == 'pypackage' %}
   schedule:
   - cron: '0 1 * * *'


### PR DESCRIPTION
The `deploy.yml` workflow (which is not in the cookiecutter yet) tries to call `ci.yml` so `ci.yml` needs to be callable by other workflows. See https://github.com/hypothesis/h-periodic/pull/260

In the longer term I think we may want to speed up `deploy.yml` by having it *not* call `ci.yml` but I'm not 100% sure of that yet and it won't do any harm for `ci.yml` be callable by other workflows even if none actually do call it anyway.