### PR TITLE
POC: Allow customization of `bin/create-db` and call it in `dev`

### DIFF
--- a/_shared/project/bin/create-db
+++ b/_shared/project/bin/create-db
@@ -6,3 +6,7 @@
 #
 #     create-db <DB_NAME>
 make services args="exec postgres psql -U postgres -c 'CREATE DATABASE $1;'" > /dev/null 2>&1 || true
+
+{% if include_exists("create_db/tail") %}
+    {{- include("create_db/tail", indent=4) -}}
+{% endif %}

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -74,7 +74,7 @@ depends =
 {% if cookiecutter.get("db") == "yes" or include_exists("tox/allowlist_externals") %}
 allowlist_externals =
 {% if cookiecutter.get("db") == "yes" %}
-    tests,functests: sh
+    dev,tests,functests: sh
 {% endif %}
 {% if include_exists("tox/allowlist_externals") %}
     {{- include("tox/allowlist_externals", indent=4) -}}
@@ -91,11 +91,12 @@ commands_pre =
 {% endif %}
 commands =
 {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
-    dev: {posargs:supervisord -c conf/supervisord-dev.conf}
 {% if cookiecutter.get("db") == "yes" %}
     tests: sh bin/create-db {{ cookiecutter.package_name }}_test
     functests: sh bin/create-db {{ cookiecutter.package_name }}_functests
+    dev: sh bin/create-db postgres
 {% endif %}
+    dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     format: black {{ cookiecutter.package_name }} tests bin
     format: isort --atomic {{ cookiecutter.package_name }} tests bin
     checkformatting: black --check {{ cookiecutter.package_name }} tests bin


### PR DESCRIPTION
One possible solution to adding a Metabase use in Report to all the DBs when they start for:

 * https://github.com/hypothesis/report/issues/49

This PR:

 * Calls `bin/create-db` in dev too (with the default DB name)
 * Adds a customisation point in `create-db` to add more commands

We could avoid the customization point by going off template, but without `bin/create-db` being called in dev this wouldn't have the desired effect.

## What else might we do?

 * We could go off template for both `tox.ini` and/or `bin/create-db` in Report. But `tox.ini` is a very complicated bit of the templating system and wouldn't be nice to keep in step by hand
 * There might be things we can do in `dockercompose` to run some scripts as Postgres starts, but we'd need the tests / functests DBs to exist already. (See https://hub.docker.com/_/postgres/ "Initialisation scripts")
 * Something else?

## Questions

Does this cause any particular problems? It seems like it should gracefully fail when calling `CREATE DATABASE` in the first command.