### PR TITLE
Fix `make services` in the `pypackage` cookiecutter

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -126,14 +126,13 @@ def main():
 
         project_ignore_patterns = cookiecutter.get("__ignore__")
 
-        template_ignore_patterns = [".git/*"]
+        template_ignore_patterns = [".git/*", "docker-compose.yml"]
 
         {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
         template_ignore_patterns.extend([
             "{{ cookiecutter.package_name }}/__init__.py",
             "{{ cookiecutter.package_name }}/app.py",
             "Dockerfile",
-            "docker-compose.yml",
             "package.json",
             "yarn.lock",
             ".docker.env",

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -48,6 +48,9 @@ deps =
 {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
     pip-tools
 {% elif cookiecutter._directory == 'pypackage' %}
+{% if cookiecutter.get("services") == "yes" %}
+    dockercompose: docker-compose
+{% endif %}
     dev: ipython
     format,checkformatting: black
     format,checkformatting: isort
@@ -104,7 +107,6 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle {{ cookiecutter.package_name }} tests bin
     lint: pycodestyle {{ cookiecutter.package_name }} tests bin
-    dockercompose: docker-compose {posargs}
 {% else %}
     dev: {posargs:ipython --classic --no-banner --no-confirm-exit}
     format: black src tests bin
@@ -115,6 +117,9 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle src tests bin
     lint: pycodestyle src tests bin
+{% endif %}
+{% if cookiecutter.get("services") == "yes" %}
+    dockercompose: docker-compose {posargs}
 {% endif %}
     tests: coverage run -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
     functests: pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -10,6 +10,7 @@
     "console_script": ["no", "yes"],
     "devdata": ["no", "yes"],
     "services": ["no", "yes"],
+    "db": ["no", "yes"],
     "create_github_repo": ["no", "yes"],
     "dependabot_pip_interval": ["monthly", "weekly", "daily"],
     "__entry_point": "{{ cookiecutter.slug }}",

--- a/pypackage/{{ cookiecutter.slug }}/docker-compose.yml
+++ b/pypackage/{{ cookiecutter.slug }}/docker-compose.yml
@@ -1,0 +1,1 @@
+../../_shared/project/docker-compose.yml


### PR DESCRIPTION
## Problem

`make services` is currently broken in the `pypackage` cookiecutter:

```console
$ cd /tmp
$ cookiecutter gh:hypothesis/cookiecutters --directory pypackage --no-input services=yes
$ cd my-python-package
$ make services
ERROR: unknown environment 'dockercompose'
make: *** [Makefile:11: services] Error 1
```

## Solution

This PR fixes up various templates to remove the assumption that the `"services"` and `"db"` options belong only to the `pyapp` and `pyramid-app` cookiecutters, making these work with the `pypackage` cookiecutter as well.

## Testing

```console
$ cd /tmp
$ cookiecutter gh:hypothesis/cookiecutters --checkout fix-make-services-in-packages --directory pypackage --no-input services=yes db=yes
$ cd my-python-package
$ make services
```

`make services` actually crashes because the starter `docker-compose.yml` from the cookiecutter doesn't seem to work. We may want to fix that. But if you manually fix `docker-compose.yml` (which is a file you're gonna want to change anyway) then it works.

You can also run `make template checkout=fix-make-services-in-packages` in https://github.com/hypothesis/cookiecutter-pypackage-test, https://github.com/hypothesis/cookiecutter-pyapp-test and https://github.com/hypothesis/cookiecutter-pyramid-app-test to make sure this PR doesn't make any unwanted changes, and can try setting `services` and `db` to `yes` in those projects.

Also https://github.com/hypothesis/data-tasks/pull/3 applies this change to the data-tasks project.

## Known limitations

We don't necessarily have to fix these right now, but I think the `services` and `db` options could have some improvements / finishing up:

The `services` option isn't really finished in the cookiecutter. For example there's no way for a project to customize [the `services` section in `ci.yml`](https://github.com/hypothesis/cookiecutters/blob/e335a7f3156d66a29a4a5d51c623635adc279307/_shared/project/.github/workflows/ci.yml#L17-L22) to add arbitrary services (other than Postgres) on GitHub Actions. As it happens data-tasks only needs Postgres so we don't need to handle this yet.

The starter `docker-compose.yml` file that the cookiecutter outputs for you if `services` is `yes` seems to be broken. The cookiecutter doesn't attempt to update this file at all, it generates a starter file then just leaves the projects to edit `docker-compose.yml` directly (`docker-compose.yml` is part of a [list of files that `make template` ignores](https://github.com/hypothesis/cookiecutters/blob/e335a7f3156d66a29a4a5d51c623635adc279307/_shared/hooks/post_gen_project.py#L129-L163) when updating existing files). But still, it'd be nice if the starter file at least worked. Or perhaps `docker-compose.yml` should be properly templated.

When `db` is `yes` Postgres should probably be added to `docker-compose.yml` for you.