### PR TITLE
Add GitHub Actions deployment workflow templates

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -38,6 +38,14 @@ def remove_conditional_files():
     paths_to_remove.extend(["tests/functional/cli_test.py"])
     {% endif %}
 
+    {% if not include_exists(".github/workflows/environments.json") %}
+    # The deployment workflows only make sense if environments.json exists.
+    paths_to_remove.extend([
+        ".github/workflows/deploy.yml",
+        ".github/workflows/redeploy.yml",
+    ])
+    {% endif %}
+
     for path in paths_to_remove:
         if os.path.exists(path):
             try:

--- a/_shared/local_extensions.py
+++ b/_shared/local_extensions.py
@@ -117,7 +117,7 @@ class LocalJinja2Extension(Extension):
             return ""
 
     @pass_context
-    def include_json(self, context, path):
+    def include_json(self, context, path, default=None):
         """Return the project's .cookiecutter/includes/{path} data or None.
 
         Return the contents of the project's .cookiecutter/includes/{path} JSON
@@ -125,8 +125,11 @@ class LocalJinja2Extension(Extension):
 
         Return None if the project has no .cookiecutter/includes/{path} file.
         """
-        with self._open(context, path) as file_obj:
-            return json.load(file_obj)
+        try:
+            with self._open(context, path) as file_obj:
+                return json.load(file_obj)
+        except FileNotFoundError:
+            return default
 
     def oldest(self, python_versions):
         """Return the oldest from `python_versions` by version number."""

--- a/_shared/project/.github/workflows/deploy.yml
+++ b/_shared/project/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+  docker_hub:
+    name: Docker Hub
+    needs: [ci]
+    uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
+    with:
+      Application: {% raw %}${{ github.event.repository.name }}{% endraw +%}
+    secrets: inherit
+  {% for job_id, environment in include_json(".github/workflows/environments.json", {}).items() %}
+  {{ job_id }}:
+    name: {{ environment.github_environment_name }}
+    needs: [{{ (["docker_hub"] + environment.get("needs", []))|join(", ") }}]
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: deploy
+      github_environment_name: {{ environment.get("github_environment_name", job_id) }}
+      github_environment_url: {{ environment.github_environment_url }}
+      aws_region: {{ environment.aws_region }}
+      elasticbeanstalk_application: {{ environment.elasticbeanstalk_application }}
+      elasticbeanstalk_environment: {{ environment.elasticbeanstalk_environment }}
+      docker_tag: {% raw %}${{ needs.Docker_Hub.outputs.docker_tag }}{% endraw +%}
+    secrets: inherit
+  {% endfor %}

--- a/_shared/project/.github/workflows/redeploy.yml
+++ b/_shared/project/.github/workflows/redeploy.yml
@@ -1,0 +1,29 @@
+name: Redeploy
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    {% if include_exists(".github/workflows/environments.json") %}
+    inputs:
+      {% for job_id, environment in include_json(".github/workflows/environments.json").items() %}
+      {{ job_id }}:
+        type: boolean
+        description: Redeploy {{ environment.get("github_environment_name", job_id) }}
+      {% endfor %}
+    {% endif %}
+jobs:
+  {% for job_id, environment in include_json(".github/workflows/environments.json", {}).items() %}
+  {{ job_id }}:
+    name: {{ environment.github_environment_name }}
+    if: inputs.{{ job_id }}
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
+    with:
+      operation: redeploy
+      github_environment_name: {{ environment.get("github_environment_name", job_id) }}
+      github_environment_url: {{ environment.github_environment_url }}
+      aws_region: {{ environment.aws_region }}
+      elasticbeanstalk_application: {{ environment.elasticbeanstalk_application }}
+      elasticbeanstalk_environment: {{ environment.elasticbeanstalk_environment }}
+    secrets: inherit
+  {% endfor %}

--- a/pyapp/{{ cookiecutter.slug }}/.github/workflows/deploy.yml
+++ b/pyapp/{{ cookiecutter.slug }}/.github/workflows/deploy.yml
@@ -1,0 +1,1 @@
+../../../../_shared/project/.github/workflows/deploy.yml

--- a/pyapp/{{ cookiecutter.slug }}/.github/workflows/redeploy.yml
+++ b/pyapp/{{ cookiecutter.slug }}/.github/workflows/redeploy.yml
@@ -1,0 +1,1 @@
+../../../../_shared/project/.github/workflows/redeploy.yml

--- a/pyramid-app/{{ cookiecutter.slug }}/.github/workflows/deploy.yml
+++ b/pyramid-app/{{ cookiecutter.slug }}/.github/workflows/deploy.yml
@@ -1,0 +1,1 @@
+../../../../_shared/project/.github/workflows/deploy.yml

--- a/pyramid-app/{{ cookiecutter.slug }}/.github/workflows/redeploy.yml
+++ b/pyramid-app/{{ cookiecutter.slug }}/.github/workflows/redeploy.yml
@@ -1,0 +1,1 @@
+../../../../_shared/project/.github/workflows/redeploy.yml


### PR DESCRIPTION
## Problem

All our deployed applications have a `deploy.yml` workflow, for example here's [Via's `deploy.yml`](https://github.com/hypothesis/via/blob/main/.github/workflows/deploy.yml). This file is exactly the same in every app (except for some simple variables) but is currently not generated by the cookiecutter. As a result it's labor-intensive and error-prone to maintain these files.

Every app also needs to contain a `redeploy.yml` workflow, for example here's [Via's `redeploy.yml`](https://github.com/hypothesis/via/blob/main/.github/workflows/redeploy.yml). `redeploy.yml` hasn't been added to any projects other than Via yet, but it needs to be added to them all. Same problem: this file is exactly the same in every app except for some variables and is labor-intensive and error-prone to maintain without the cookiecutter.

There's also a bunch of information about the app's QA and production environments that's duplicated between `deploy.yml` and `redeploy.yml`. Any differences between the environments referenced in the two workflows would lead to confusing misbehaviour.

## Solution

This PR adds `deploy.yml` and `redeploy.yml` templates to the `pyapp` and `pyramid-app` cookiecutters. Both templates read an `environments.json` file that must be provided by the project. Here's what the `environments.json` would look like for Via:

```json
{
  "QA": {
    "github_environment_url": "https://qa-via.hypothes.is/https://en.wikipedia.org/api/rest_v1/page/pdf/Comet_Kohoutek",
    "aws_region": "us-west-1",
    "elasticbeanstalk_application": "via",
    "elasticbeanstalk_environment": "qa"
  },
  "QA_Edu": {
    "github_environment_name": "QA (Edu)",
    "github_environment_url": "https://hypothesis.instructure.com/courses/125/assignments/878",
    "aws_region": "us-west-1",
    "elasticbeanstalk_application": "lms-via",
    "elasticbeanstalk_environment": "qa"
  },
  "Production": {
    "needs": ["QA"],
    "github_environment_url": "https://via.hypothes.is/https://en.wikipedia.org/api/rest_v1/page/pdf/Comet_Kohoutek",
    "aws_region": "us-west-1",
    "elasticbeanstalk_application": "via",
    "elasticbeanstalk_environment": "prod"
  },
  "Production_Edu": {
    "needs": ["QA_Edu"],
    "github_environment_name": "Production (Edu)",
    "github_environment_url": "https://hypothesis.instructure.com/courses/125/assignments/882",
    "aws_region": "us-west-1",
    "elasticbeanstalk_application": "lms-via",
    "elasticbeanstalk_environment": "prod"
  }
}
```

Even though we haven't applied the cookiecutter to most of our applications yet, my intention is to use the cookiecutter to generate just the `deploy.yml` and `redeploy.yml` files in each project (not committing any of the other files that the cookiecutter adds or modifies) rather than manually adding `redeploy.yml` to every project. For examples of how I intend to do this see https://github.com/hypothesis/via/pull/829 and https://github.com/hypothesis/h-periodic/pull/262.

## Testing

This PR shouldn't make any changes to projects that don't have an `environments.json` file, for example <https://github.com/hypothesis/cookiecutter-pyramid-app-test>:

```console
cd /tmp
git clone https://github.com/hypothesis/cookiecutter-pyramid-app-test
cd cookiecutter-pyramid-app-test
make template checkout=add-deployment-workflows
git diff
```

If you add a `.cookiecutter/includes/.github/workflows/environments.json` file like the one above to `cookiecutter-pyramid-app-test` then re-run `make template checkout=add-deployment-workflows` you should see that it adds correct `deploy.yml` and `redeploy.yml` files.