### PR TITLE
Remove the default return value from `include()`

### DIFF
--- a/_shared/local_extensions.py
+++ b/_shared/local_extensions.py
@@ -155,11 +155,8 @@ class LocalJinja2Extension(Extension):
     @pass_context
     def include(self, context, path, indent=0):
         """Return the lines from the project's .cookiecutter/includes/{path} or an empty string."""
-        try:
-            with self._open(context, path) as file_obj:
-                return textwrap.indent("".join(file_obj.readlines()), " " * indent)
-        except (FileNotFoundError, NotADirectoryError):
-            return ""
+        with self._open(context, path) as file_obj:
+            return textwrap.indent("".join(file_obj.readlines()), " " * indent)
 
     @pass_context
     def include_json(self, context, path, default=None):
@@ -216,10 +213,5 @@ class LocalJinja2Extension(Extension):
     def _open(self, context, path):
         """Return the file at `path` in the project's .cookiecutter/includes dir."""
         target_dir = context["cookiecutter"].get("__target_dir__")
-
-        if not target_dir:
-            # We're creating a new project for the first time rather than
-            # updating an existing project, so there are no include files yet.
-            raise FileNotFoundError()
 
         return open(Path(target_dir) / ".cookiecutter/includes" / path, "r")

--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -100,4 +100,6 @@ jobs:
     - name: Test
       run: make frontend-test
   {% endif %}
-  {{- include(".github/workflows/ci.yml", indent=2) -}}
+  {% if include_exists(".github/workflows/ci.yml") %}
+    {{- include(".github/workflows/ci.yml", indent=2) -}}
+  {% endif %}


### PR DESCRIPTION
In an earlier iteration of the cookiecutter the `include()` function returned an empty string when the requested include file didn't exist. The idea was that a template could just do:

```jinja2
{{ include("foo") }}
```

and get the contents of the project's `.cookiecutter/includes/foo` file or nothing if the project doesn't have that include file.

This doesn't work as intended, it was based on a misunderstanding of how Jinja2 works. Templates instead need do do this every time:

```jinja2
{% if include_exists("foo") %}
  {{ include("foo") }}
{% endif %}
```

This means that the default return value of `include()` is no longer needed because it's never used. So this commit simplifies the code a little by removing the default. A template should never call `include("foo")` without first checking that `foo` exists, so it's right to crash if a template does do that.

For some explanation see:

* https://github.com/hypothesis/cookiecutters/pull/82
* https://github.com/hypothesis/cookiecutters/pull/97#discussion_r1048537834