### PR TITLE
Add `sqlalchemy` and `psycopg2` dependencies and `DATABASE_URL` and `TEST_DATABASE_URL` envvars

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -26,10 +26,6 @@ jobs:
         {{- include(".github/workflows/ci/services.yml", indent=6) -}}
       {% endif %}
     {% endif %}
-    {% if job in ["tests", "functests"] and cookiecutter.get("postgres") == "yes" %}
-    env:
-      TEST_DATABASE_URL: postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_test
-    {% endif %}
     {% if cookiecutter._directory == 'pypackage' and (job == 'tests' or job == 'functests') %}
     strategy:
       matrix:

--- a/_shared/project/requirements/prod.in
+++ b/_shared/project/requirements/prod.in
@@ -3,6 +3,10 @@ pyramid
 gunicorn
 newrelic
 {% endif %}
+{% if cookiecutter.get("postgres") == "yes" %}
+sqlalchemy
+psycopg2
+{% endif %}
 {% if include_exists("requirements/prod.in") %}
     {{- include("requirements/prod.in") -}}
 {% endif %}

--- a/_shared/project/setup.cfg
+++ b/_shared/project/setup.cfg
@@ -20,6 +20,10 @@ packages = find:
 python_requires = >={{ python_versions()|oldest|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}
 install_requires =
     importlib_metadata;python_version<"3.8."
+{% if cookiecutter.get("postgres") == "yes" %}
+    sqlalchemy
+    psycopg2
+{% endif %}
 {% if include_exists("setuptools/install_requires") %}
   {{- include("setuptools/install_requires", indent=4) -}}
 {% endif %}

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -25,6 +25,10 @@ skip_install =
 setenv =
     PYTHONUNBUFFERED = 1
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
+{% if cookiecutter.get("postgres") == "yes" %}
+    dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/postgres}
+    tests,functests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_test}
+{% endif %}
 {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
     # Make `import {{ cookiecutter.package_name }}` work in `make shell`.
     dev: PYTHONPATH = .


### PR DESCRIPTION
See: https://github.com/hypothesis/data-tasks/pull/5#issuecomment-1357461195

In https://github.com/hypothesis/cookiecutters/pull/97 I added Postgres support to the cookiecutters with a `postgres` boolean option in `cookiecutter.json` but I only tested that `make services` and `make sql` work, I didn't test that the Python code can actually connect to the project's DB.

In fact in order to connect to the DB the Python code needs the `sqlalchemy` and `psycopg2` dependencies and the `DATABASE_URL` and `TEST_DATABASE_URL` envvars.

With this PR the cookiecutter still doesn't actually generate any Python code or test that actually connects to the DB and verifies that it actually works. Maybe it should but I'm trying not to overreach here, not sure each project is gonna want to set up its DB handle in the same way. Perhaps we can consider adding that in a separate PR.