### PR TITLE
Add support for non-PyPI Python packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test sure: test-pypackage test-pyapp test-pyramid-app
 
 .PHONY: test-pypackage
 test-pypackage:
-	@bin/make_test pypackage console_script=yes db=yes devdata=yes services=yes
+	@bin/make_test pypackage console_script=yes db=yes devdata=yes pypi=yes services=yes
 
 .PHONY: test-pyapp
 test-pyapp:

--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -31,6 +31,10 @@ def remove_conditional_files():
     paths_to_remove.extend(["docker-compose.yml"])
     {% endif %}
 
+    {% if cookiecutter.get("pypi") != "yes" %}
+    paths_to_remove.extend([".github/workflows/pypi.yml"])
+    {% endif %}
+
     {% if cookiecutter.get("console_script") != "yes" %}
     paths_to_remove.extend(["src/{{ cookiecutter.package_name }}/__main__.py"])
     paths_to_remove.extend(["src/{{ cookiecutter.package_name }}/cli.py"])

--- a/_shared/project/README.md
+++ b/_shared/project/README.md
@@ -2,7 +2,7 @@
     {% if cookiecutter.get("visibility") == "public" %}
     <a href="{{ cookiecutter.__github_url }}/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/workflow/status/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}/CI/main"></a>
     {% endif %}
-    {% if cookiecutter._directory == 'pypackage' %}
+    {% if cookiecutter.get("pypi") == "yes" %}
     <a href="{{ cookiecutter.__pypi_url }}"><img src="https://img.shields.io/pypi/v/{{ cookiecutter.slug }}"></a>
     {% endif %}
     <a><img src="https://img.shields.io/badge/python-{{ python_versions()|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT)|separator(" | ") }}-success"></a>
@@ -25,7 +25,11 @@
     First [install pipx](https://pypa.github.io/pipx/#install-pipx) then run:
 
     ```terminal
+{% if cookiecutter.get("pypi") == "yes" %}
     pipx install {{ cookiecutter.slug }}
+{% else %}
+    pipx install git+{{ cookiecutter.__github_url }}.git
+{% endif %}
     ```
 
     You now have {{ cookiecutter.name }} installed! For some help run:
@@ -270,7 +274,7 @@
     {{ installing()|dedent }}
 {% endif %}
 {{ setting_up()|dedent }}
-{% if cookiecutter._directory == 'pypackage' -%}
+{% if cookiecutter.get("pypi") == "yes" -%}
     {{ releasing()|dedent }}
 {% endif %}
 {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] -%}

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -12,6 +12,7 @@
     "postgres": ["no", "yes"],
     "create_github_repo": ["no", "yes"],
     "dependabot_pip_interval": ["monthly", "weekly", "daily"],
+    "pypi": ["no", "yes"],
     "__postgres_port": "{{ random_port_number() }}",
     "__entry_point": "{{ cookiecutter.slug }}",
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",


### PR DESCRIPTION
Add a boolean `pypi` option to `cookiecutter.json` and only include the stuff around publishing the package to PyPI if `pypi` is `yes`. Otherwise support installing the package directly from GitHub.

This enables us to create things like development command line tools and just install them directly from the head of the `main` GitHub branch, no need to think of a unique name and release them to PyPI (or to have releases at all).

Fixes https://github.com/hypothesis/cookiecutters/issues/55.

Unfortunately the new `pypi` setting that this project adds defaults to `no`, which means we're going to have to add `"pypi": "yes"` to the `cookiecutter.json`'s of all our existing packages which is a bit of a pain. But all boolean settings in `cookiecutter.json` default to `no` and it'd be undesirable to have some that default to `yes`: when you generate a new project cookiecutter prompts you interactively for each setting and each time offers `no` as the default, it'd be a total snare if it then suggested `yes` as the default for one of the settings. I think `no` is also a good default for everything: it means you get a minimal project by default and can opt-in to optional features one-by-one.

### Testing

- [x] Projects that **do** have `pypi` set to `yes` will be unaffected by this PR. For example if you clone https://github.com/hypothesis/cookiecutter-pypackage-test, add `"pypi": "yes"` to `cookiecutter.json`, and run `make template checkout=support-non-pypi-packages`, `make template` should not make any changes.

- If you generate a new project with `pypi=no` (`cookiecutter gh:hypothesis/cookiecutters --directory pypackage --checkout support-non-pypi-packages --no-input console_script=yes pypi=no`, the `pypi=no` isn't really necessary because it's the default) then:

  - [x] There'll be no PyPI badge in `README.md`
  - [x] The install command in `README.md` will be a command for installing the project directly from git: `pipx install git+https://github.com/hypothesis/foo.git` 
  - [x] The docs about how to release a new version of the package will be missing from `README.md`
  - [x] The `.github/workflows/pypi.yml` file will be missing
  
  If you then change `pypi` to `yes` in `cookiecutter.json` and run `make template checkout=support-non-pypi-packages` then:

  - [x] A PyPI badge will be added to the top of `README.md`
  - [x] The install command in `README.md` will change to a PyPI one
  - [x] Docs about how to release a new version of the package will be added to `README.md`
  - [x] `.github/workflows/pypi.yml` will be added