### PR TITLE
Don't update the copyright year

### DIFF
--- a/_shared/project/LICENSE
+++ b/_shared/project/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) {% now 'utc', '%Y' %}, {{ cookiecutter.copyright_holder }}
+Copyright (c) {{ cookiecutter.__copyright_year }}, {{ cookiecutter.copyright_holder }}
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -18,6 +18,7 @@
     "__docker_namespace": "{{ cookiecutter.github_owner }}",
     "__docker_network": "{{ cookiecutter.package_name }}_default",
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",
+    "__copyright_year": "{% now 'utc', '%Y' %}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pyapp",
     "__hdev_project_type": "application",

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -16,6 +16,7 @@
     "__entry_point": "{{ cookiecutter.slug }}",
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",
     "__pypi_url": "https://pypi.org/project/{{ cookiecutter.slug }}",
+    "__copyright_year": "{% now 'utc', '%Y' %}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pypackage",
     "__hdev_project_type": "library",

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -26,5 +26,6 @@
     "__hdev_project_type": "application",
     "__ignore__": "",
     "__target_dir__": "",
+    "__copyright_year": "2022",
     "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
 }


### PR DESCRIPTION
Don't update the copyright year in the `LICENSE` file to the current year. Otherwise every year the cookiecutter is going to want to update the `LICENSE` file in every project.

If we actually _want_ to automate updating copyright years one day we can do that: just write a script the reads `cookiecutter.json`, changes `__copyright_year`, writes it back, and runs `make template`. [Commando](https://github.com/hypothesis/commando) or another tool could be used to run such a script on every project and send PRs. But I don't think we need to update these.

Anyway, this PR just prevents `make template` from making this change by itself, which I think is clearly undesirable