### PR TITLE
Fix `ci.yml` README badge

### DIFF
--- a/_shared/project/README.md
+++ b/_shared/project/README.md
@@ -1,6 +1,6 @@
 {%- macro badges() %}
     {% if cookiecutter.get("visibility") == "public" %}
-    <a href="{{ cookiecutter.__github_url }}/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/workflow/status/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}/CI/main"></a>
+    <a href="{{ cookiecutter.__github_url }}/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}/ci.yml?branch=main"></a>
     {% endif %}
     {% if cookiecutter.get("pypi") == "yes" %}
     <a href="{{ cookiecutter.__pypi_url }}"><img src="https://img.shields.io/pypi/v/{{ cookiecutter.slug }}"></a>


### PR DESCRIPTION
The first badge at the top of all our project README's is broken (see https://github.com/hypothesis/gha-token/blob/main/README.md for example). This was broken by a https://shields.io/ change, see: https://github.com/badges/shields/issues/8671
