### PR TITLE
Fix `update_repos.yml` when run on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 on:
   push:
   workflow_dispatch:
+  schedule:
+  - cron: '0 1 * * *'
 jobs:
   Test_pypackage:
     name: Test pypackage

--- a/.github/workflows/update_repos.yml
+++ b/.github/workflows/update_repos.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Find repos
         id: find_repos
         run: |
-          if [ "${{ inputs.repos }}" = "__all_cookiecuttered_repos__" ]
+          if [ "${{ inputs.repos || '__all_cookiecuttered_repos__' }}" = "__all_cookiecuttered_repos__" ]
           then
             echo "REPOS=$(bin/find_repos | xargs)" >> $GITHUB_OUTPUT
           else

--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -40,10 +40,8 @@ on:
 {% endif %}
   workflow_dispatch:
   workflow_call:
-  {% if cookiecutter._directory == 'pypackage' %}
   schedule:
   - cron: '0 1 * * *'
-  {% endif %}
 jobs:
   {% for job in ['format', 'lint', 'tests', 'coverage', 'functests'] %}
   {{ job|capitalize }}:

--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -12,6 +12,8 @@ filterwarnings = [
     "error", # Fail the tests if there are any warnings.
     "ignore:^find_module\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
     "ignore:^FileFinder.find_loader\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
+    "ignore:^pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
+    "ignore:^Deprecated call to .pkg_resources\\.declare_namespace\\('.*'\\).\\.:DeprecationWarning:pkg_resources",
     {% if include_exists("pytest/filterwarnings") %}
         {{- include("pytest/filterwarnings", indent=4) -}}
     {% endif %}


### PR DESCRIPTION
The `update_repos.yml` workflow is failing when run automatically by its
monthly schedule. For example see:

https://github.com/hypothesis/cookiecutters/actions/runs/4298577433

But the workflow is working when run manually:

https://github.com/hypothesis/cookiecutters/actions/runs/4365452102

The reason is that `inputs.repos` defaults to
`'__all_cookiecuttered_repos__'` when the workflow is run manually but
when the workflow is run automatically by its schedule the default
doesn't apply and `inputs.repos` is set to `''`.
