### PR TITLE
Expose port in `Dockerfile`

### DIFF
--- a/_shared/project/Dockerfile
+++ b/_shared/project/Dockerfile
@@ -16,6 +16,10 @@ RUN apk add --no-cache --virtual \
 
 COPY . .
 
+{% if cookiecutter.get("_directory") == "pyramid-app" %}
+EXPOSE {{ cookiecutter.port }}
+{% endif %}
+
 USER hypothesis
 
 CMD /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf


### PR DESCRIPTION
This is necessary to get the `Dockerfile` working correctly in production. The port is also mentioned in the `-p` argument of the `docker run` command in `Makefile`: both seem to be necessary.