### PR TITLE
Add a `/_status` endpoint to Pyramid apps

### DIFF
--- a/pyramid-app/{{ cookiecutter.slug }}/tests/functional/app_test.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/functional/app_test.py
@@ -1,11 +1,21 @@
+import pytest
 from webtest import TestApp
 
 from {{ cookiecutter.package_name }}.app import create_app
 
 
-def test_it():
-    app = TestApp(create_app({}))
-
+def test_index(app):
     response = app.get("/")
 
-    assert response.json == {"Hello": "Pyramid!"}
+    assert response.text == "Hello world!"
+
+
+def test_status(app):
+    response = app.get("/_status")
+
+    assert response.json == {"status": "okay"}
+
+
+@pytest.fixture
+def app():
+    return TestApp(create_app({}))

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/app_test.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/app_test.py
@@ -12,4 +12,8 @@ def test_create_app():
 
 
 def test_index():
-    assert app.index(sentinel.request) == {"Hello": "Pyramid!"}
+    assert app.index(sentinel.request) == "Hello world!"
+
+
+def test_status():
+    assert app.status(sentinel.request) == {"status": "okay"}

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
@@ -5,12 +5,18 @@ from pyramid.view import view_config
 def create_app(_=None, **settings):
     with Configurator(settings=settings) as config:
         config.add_route("index", "/")
+        config.add_route("status", "/_status")
 
         config.scan()
 
         return config.make_wsgi_app()
 
 
-@view_config(route_name="index", renderer="json")
+@view_config(route_name="index", renderer="string")
 def index(_request):
-    return {"Hello": "Pyramid!"}
+    return "Hello world!"
+
+
+@view_config(route_name="status", renderer="json", http_cache=0)
+def status(_request):
+    return {"status": "okay"}


### PR DESCRIPTION
This is needed to deploy the app to production: Elastic Beanstalk needs a working healthcheck endpoint otherwise deploying fails