### PR TITLE
Extract a separate `bin/make_docker_run` script

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -12,7 +12,7 @@ def remove_conditional_files():
     paths_to_remove = []
 
     {% if cookiecutter.get("docker") != "yes" %}
-    paths_to_remove.extend(["docker.env", "Dockerfile"])
+    paths_to_remove.extend(["docker.env", "Dockerfile", "bin/make_docker_run"])
     {% endif %}
 
     {% if cookiecutter.get("frontend") != "yes" %}

--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -166,32 +166,15 @@ template: python
 	@pyenv exec tox -e template -- $$(if [ -n "$${template+x}" ]; then echo "--template $$template"; fi) $$(if [ -n "$${checkout+x}" ]; then echo "--checkout $$checkout"; fi) $$(if [ -n "$${directory+x}" ]; then echo "--directory $$directory"; fi)
 
 {% if cookiecutter.get("docker") == "yes" %}
-DOCKER_TAG = dev
-
 .PHONY: docker
 $(call help,make docker,"make the app's docker image")
 docker:
-	@git archive --format=tar HEAD | docker build -t hypothesis/{{ cookiecutter.slug }}:$(DOCKER_TAG) -
+	@git archive --format=tar HEAD | docker build -t hypothesis/{{ cookiecutter.slug }}:dev -
 
 .PHONY: docker-run
 $(call help,make docker-run,"run the app's docker image")
 docker-run:
-	@docker run \
-		--add-host host.docker.internal:host-gateway \
-{% if has_services() %}
-		--net {{ cookiecutter.__docker_network }} \
-{% endif %}
-		--env-file .docker.env \
-{% if cookiecutter.get("devdata") == "yes" %}
-		--env-file .devdata.env \
-{% endif %}
-{% if cookiecutter.get("_directory") == "pyramid-app" %}
-		-p {{ cookiecutter.port }}:{{ cookiecutter.port }} \
-{% endif %}
-{% if include_exists("make_docker_run") %}
-	{{- include("make_docker_run") -}}
-{% endif %}
-		{{ cookiecutter.__docker_namespace }}/{{ cookiecutter.slug }}:$(DOCKER_TAG)
+	@bin/make_docker_run
 
 {% endif %}
 .PHONY: clean

--- a/_shared/project/bin/make_docker_run
+++ b/_shared/project/bin/make_docker_run
@@ -1,0 +1,17 @@
+#!/bin/bash
+docker run \
+    --add-host host.docker.internal:host-gateway \
+{% if has_services() %}
+    --net {{ cookiecutter.__docker_network }} \
+{% endif %}
+    --env-file .docker.env \
+{% if cookiecutter.get("devdata") == "yes" %}
+    --env-file .devdata.env \
+{% endif %}
+{% if cookiecutter.get("_directory") == "pyramid-app" %}
+    -p {{ cookiecutter.port }}:{{ cookiecutter.port }} \
+{% endif %}
+{% if include_exists("make_docker_run") %}
+    {{- include("make_docker_run", indent=4) -}}
+{% endif %}
+    {{ cookiecutter.__docker_namespace }}/{{ cookiecutter.slug }}:dev

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -16,7 +16,7 @@
     "docker": ["no", "yes"],
     "__postgres_port": "{{ random_port_number() }}",
     "__docker_namespace": "{{ cookiecutter.github_owner }}",
-    "__docker_network": "{{ cookiecutter.package_name }}_default",
+    "__docker_network": "{{ cookiecutter.slug }}_default",
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",
     "__copyright_year": "{% now 'utc', '%Y' %}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],

--- a/pyapp/{{ cookiecutter.slug }}/bin/make_docker_run
+++ b/pyapp/{{ cookiecutter.slug }}/bin/make_docker_run
@@ -1,0 +1,1 @@
+../../../_shared/project/bin/make_docker_run

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -19,7 +19,7 @@
     "docker": ["no", "yes"],
     "__postgres_port": "{{ random_port_number() }}",
     "__docker_namespace": "{{ cookiecutter.github_owner }}",
-    "__docker_network": "{{ cookiecutter.package_name }}_default",
+    "__docker_network": "{{ cookiecutter.slug }}_default",
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pyramid-app",

--- a/pyramid-app/{{ cookiecutter.slug }}/bin/make_docker_run
+++ b/pyramid-app/{{ cookiecutter.slug }}/bin/make_docker_run
@@ -1,0 +1,1 @@
+../../../_shared/project/bin/make_docker_run


### PR DESCRIPTION
This allows projects to completely replace the `docker run` command by adding `bin/make_docker_run` to the `ignore` list in their `cookiecutter.json`.
