### PR TITLE
Tweak some `make help` strings

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -76,7 +76,11 @@ checkformatting: python
 	@pyenv exec tox -qe checkformatting
 
 .PHONY: test
+{% if cookiecutter.get("_directory") in ["pyapp", "pyramid-app"] %}
+$(call help,make test,"run the unit tests")
+{% else %}
 $(call help,make test,"run the unit tests in Python {{ python_versions()|first|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
+{% endif %}
 test: python
 	@pyenv exec tox -qe tests
 
@@ -98,7 +102,11 @@ coverage: python
 {% endif %}
 
 .PHONY: functests
+{% if cookiecutter.get("_directory") in ["pyapp", "pyramid-app"] %}
+$(call help,make functests,"run the functional tests")
+{% else %}
 $(call help,make functests,"run the functional tests in Python {{ python_versions()|first|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}")
+{% endif %}
 functests: python
 	@pyenv exec tox -qe functests
 


### PR DESCRIPTION
It's a bit weird to say "Run the functional tests in Python 3.10" when
the app only supports one version of Python. This makes sense in the
context of packages that support multiple versions of Python where there
are multiple `make test-pyXY` commands for different versions of Python:

    $ make help
    ...
    make test: run the unit tests in Python 3.10
    make test-py39: run the unit tests in Python 3.9
    make test-py38: run the unit tests in Python 3.8
    make test-py37: run the unit tests in Python 3.7
    ...
    make functests: run the functional tests in Python 3.10
    make functests-py39: run the functional tests in Python 3.9
    make functests-py38: run the functional tests in Python 3.8
    make functests-py37: run the functional tests in Python 3.7
    ...

But it looks weird in the context of single-Python-version apps so
remove this for apps but leave it for packages.
