### PR TITLE
Add the localhost URL and port to the README

### DIFF
--- a/_shared/project/README.md
+++ b/_shared/project/README.md
@@ -104,6 +104,15 @@
     {% endif %}
     make help
     ```
+    {% if include_exists("hacking/setting_up.md") %}
+
+    {{ include("hacking/setting_up.md") -}}
+    {% else %}
+    {% if cookiecutter._directory == "pyramid-app" %}
+
+    To run {{ cookiecutter.name }} locally run `make dev` and visit http://localhost:{{ cookiecutter.port }}.
+    {% endif %}
+    {% endif %}
 {% endmacro %}
 
 {%- macro releasing() %}


### PR DESCRIPTION
Add a line to the `README.md` of Pyramid apps telling the user to run
`make dev` and giving them a link to the localhost URL at which to visit
the app.

Also add support for a `hacking/setting_up.md` include that can be used
to replace the new line. For example Via will need to use this because
its localhost ports work differently than other apps. But generally any
app that wants to add more steps here can use this.
