### PR TITLE
Ignore pkg_resources deprecation warning

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -12,7 +12,7 @@ filterwarnings = [
     "error", # Fail the tests if there are any warnings.
     "ignore:^find_module\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
     "ignore:^FileFinder.find_loader\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
-    "ignore:^pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
+    "ignore:^pkg_resources is deprecated as an API:DeprecationWarning:pyramid",
     "ignore:^Deprecated call to .pkg_resources\\.declare_namespace\\('.*'\\).\\.:DeprecationWarning:pkg_resources",
     {% if include_exists("pytest/filterwarnings") %}
         {{- include("pytest/filterwarnings", indent=4) -}}


### PR DESCRIPTION
The tests are broken on main because the pattern is no longer matching
this deprecation warning for some reason, e.g.

https://github.com/hypothesis/cookiecutters/actions/runs/5384759383/jobs/9773054098
