### PR TITLE
Add full Postgres database support to the cookiecutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,21 @@ jobs:
   Test_pypackage:
     name: Test pypackage
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15.3-alpine
+        ports:
+        - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options:
+          --health-cmd pg_isready
+          --health-interval 1s
     steps:
+      - name: Create test databases
+        run: |
+          psql -U postgres -h localhost -c 'CREATE DATABASE my_python_package_tests'
+          psql -U postgres -h localhost -c 'CREATE DATABASE my_python_package_functests'
       - uses: actions/checkout@v3
       - name: Install Python 3.10
         uses: actions/setup-python@v4
@@ -37,7 +51,21 @@ jobs:
   Test_pyapp:
     name: Test pyapp
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15.3-alpine
+        ports:
+        - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options:
+          --health-cmd pg_isready
+          --health-interval 1s
     steps:
+      - name: Create test databases
+        run: |
+          psql -U postgres -h localhost -c 'CREATE DATABASE my_python_app_tests'
+          psql -U postgres -h localhost -c 'CREATE DATABASE my_python_app_functests'
       - uses: actions/checkout@v3
       - name: Install Python 3.10
         uses: actions/setup-python@v4
@@ -54,7 +82,21 @@ jobs:
   Test_pyramid-app:
     name: Test pyramid-app
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15.3-alpine
+        ports:
+        - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options:
+          --health-cmd pg_isready
+          --health-interval 1s
     steps:
+      - name: Create test databases
+        run: |
+          psql -U postgres -h localhost -c 'CREATE DATABASE my_pyramid_app_tests'
+          psql -U postgres -h localhost -c 'CREATE DATABASE my_pyramid_app_functests'
       - uses: actions/checkout@v3
       - name: Install Python 3.10
         uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ test sure: test-pypackage test-pyapp test-pyramid-app
 
 .PHONY: test-pypackage
 test-pypackage:
-	@bin/make_test pypackage console_script=yes devdata=yes postgres=yes pypi=yes
+	@bin/make_test pypackage console_script=yes devdata=yes postgres=yes __postgres_port=5432 pypi=yes
 
 .PHONY: test-pyapp
 test-pyapp:
-	@bin/make_test pyapp devdata=yes docker=yes postgres=yes
+	@bin/make_test pyapp devdata=yes docker=yes postgres=yes __postgres_port=5432
 
 .PHONY: test-pyramid-app
 test-pyramid-app:
-	@bin/make_test pyramid-app devdata=yes docker=yes frontend=yes postgres=yes
+	@bin/make_test pyramid-app devdata=yes docker=yes frontend=yes postgres=yes __postgres_port=5432

--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -26,6 +26,16 @@ def remove_conditional_files():
         "conf/alembic.ini",
         "{{ cookiecutter.package_name }}/migrations/env.py",
         "{{ cookiecutter.package_name }}/migrations/script.py.mako",
+        "{{ cookiecutter.package_name }}/db.py",
+        "{{ cookiecutter.package_name }}/models/__init__.py",
+        "tests/factories/__init__.py",
+        "tests/factories/factoryboy_sqlalchemy_session.py",
+    ])
+    {% endif %}
+
+    {% if not (cookiecutter.get("postgres") == "yes" or cookiecutter._directory == "pyramid-app") %}
+    paths_to_remove.extend([
+        "tests/conftest.py",
     ])
     {% endif %}
 
@@ -150,13 +160,18 @@ def main():
         template_ignore_patterns.extend([
             "{{ cookiecutter.package_name }}/__init__.py",
             "{{ cookiecutter.package_name }}/app.py",
+            "{{ cookiecutter.package_name }}/db.py",
+            "{{ cookiecutter.package_name }}/models/__init__.py",
             "Dockerfile",
             "package.json",
             "yarn.lock",
             ".docker.env",
             "{{ cookiecutter.package_name }}/pshell.py",
             "tests/__init__.py",
+            "tests/conftest.py",
+            "tests/factories/__init__.py",
             "tests/unit/__init__.py",
+            "tests/unit/conftest.py",
             "tests/unit/{{ cookiecutter.package_name }}/__init__.py",
             "tests/unit/{{ cookiecutter.package_name }}/app_test.py",
             "tests/functional/__init__.py",

--- a/_shared/project/db.py
+++ b/_shared/project/db.py
@@ -1,0 +1,62 @@
+import alembic.command
+import alembic.config
+{% if cookiecutter.get("_directory") == "pyramid-app" %}
+import zope.sqlalchemy
+{% endif %}
+from sqlalchemy import MetaData{% if cookiecutter.get("_directory") == "pyramid-app" %}, create_engine{% endif %}, text
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass{% if cookiecutter.get("_directory") == "pyramid-app" %}, Session{% endif %}
+
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix_%(column_0_N_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_N_name)s_%(referred_table_name)s_%(referred_column_0_N_name)s",
+            "pk": "pk_%(table_name)s",
+        }
+    )
+
+
+def stamp(engine):  # pragma: no cover
+    """If the DB isn't already stamped then stamp it with the latest revision."""
+    stamped = False
+
+    with engine.connect() as connection:
+        try:
+            if connection.execute(text("select * from alembic_version")).first():
+                stamped = True
+        except ProgrammingError:
+            pass
+
+    if not stamped:
+        alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
+{% if cookiecutter.get("_directory") == "pyramid-app" %}
+
+
+def includeme(config):  # pragma: no cover
+    engine = create_engine(config.registry.settings["database_url"])
+
+    def db_session(request):
+        """Return the SQLAlchemy session for the given request."""
+        session = Session(engine, info={"request": request})
+
+        # Register the session with pyramid_tm/transaction so that they'll
+        # create a new DB transaction for each request and close the session at
+        # the end of the request.
+        zope.sqlalchemy.register(session, transaction_manager=request.tm)
+
+        return session
+
+    if config.registry.settings.get("dev"):
+        # Create the database tables if they don't already exist.
+        Base.metadata.create_all(engine)
+        stamp(engine)
+
+    # Make the SQLAlchemy session available as `request.db`.
+    # `reify=True` means it'll create only one session per request.
+    config.add_request_method(db_session, name="db", reify=True)
+{% endif %}

--- a/_shared/project/requirements/prod.in
+++ b/_shared/project/requirements/prod.in
@@ -7,6 +7,10 @@ newrelic
 sqlalchemy
 psycopg2
 alembic
+{% if cookiecutter.get("_directory") == "pyramid-app" %}
+pyramid-tm
+zope.sqlalchemy
+{% endif %}
 {% endif %}
 {% if include_exists("requirements/prod.in") %}
     {{- include("requirements/prod.in") -}}

--- a/_shared/project/tests/conftest.py
+++ b/_shared/project/tests/conftest.py
@@ -1,0 +1,70 @@
+{% if cookiecutter.get("postgres") == "yes" %}
+from os import environ
+
+{% endif %}
+import pytest
+{% if cookiecutter.get("postgres") == "yes" %}
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from {{ cookiecutter.package_name }}.db import Base
+from tests.factories.factoryboy_sqlalchemy_session import (
+    clear_factoryboy_sqlalchemy_session,
+    set_factoryboy_sqlalchemy_session,
+)
+{% endif %}
+{% if cookiecutter.get("postgres") == "yes" %}
+
+
+@pytest.fixture(scope="session")
+def db_engine():
+    engine = create_engine(environ["DATABASE_URL"])
+
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+
+    return engine
+
+
+@pytest.fixture(scope="session")
+def db_sessionfactory():
+    return sessionmaker()
+
+
+@pytest.fixture
+def db_session(db_engine, db_sessionfactory):
+    """Return the SQLAlchemy database session.
+
+    This returns a session that is wrapped in an external transaction that is
+    rolled back after each test, so tests can't make database changes that
+    affect later tests.  Even if the test (or the code under test) calls
+    session.commit() this won't touch the external transaction.
+
+    This is the same technique as used in SQLAlchemy's own CI:
+    https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
+    """
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = db_sessionfactory(
+        bind=connection, join_transaction_mode="create_savepoint"
+    )
+    set_factoryboy_sqlalchemy_session(session)
+
+    yield session
+
+    clear_factoryboy_sqlalchemy_session()
+    session.close()
+    transaction.rollback()
+    connection.close()
+{% endif %}
+{% if cookiecutter._directory == "pyramid-app" %}
+
+
+@pytest.fixture
+def pyramid_settings():
+{% if cookiecutter.get("postgres") == "yes" %}
+    return {"database_url": environ["DATABASE_URL"]}
+{% else %}
+    return {}
+{% endif %}
+{% endif %}

--- a/_shared/project/tests/factories/factoryboy_sqlalchemy_session.py
+++ b/_shared/project/tests/factories/factoryboy_sqlalchemy_session.py
@@ -1,0 +1,48 @@
+import sys
+
+from factory.alchemy import SQLAlchemyModelFactory
+
+
+def set_factoryboy_sqlalchemy_session(session, persistence=None):
+    # Set the Meta.sqlalchemy_session option on all our SQLAlchemy test factory
+    # classes. We can't do it in the normal Factory Boy way:
+    #
+    #     class MyFactory:
+    #         class Meta:
+    #             sqlalchemy_session = session
+    #
+    # Because we don't have `session` available to us at import time.
+    # So we have to do it this way instead.
+    #
+    # See:
+    # https://factoryboy.readthedocs.io/en/latest/orms.html#sqlalchemy
+    # https://factoryboy.readthedocs.io/en/latest/reference.html#factory.Factory._meta
+    for factory_class in _sqlalchemy_factory_classes():
+        # pylint:disable=protected-access
+        factory_class._meta.sqlalchemy_session = session
+
+        if persistence:
+            factory_class._meta.sqlalchemy_session_persistence = persistence
+
+
+def clear_factoryboy_sqlalchemy_session():
+    # Delete the sqlalchemy session from all our test factories.
+    # Just in case, so we don't have references to the session hanging about.
+    for factory_class in _sqlalchemy_factory_classes():
+        factory_class._meta.sqlalchemy_session = None  # pylint:disable=protected-access
+
+
+def _sqlalchemy_factory_classes():
+    """Return all the SQLAlchemy factory classes from tests.factories."""
+
+    # Get the package that this module belongs to.
+    package = sys.modules[sys.modules[__name__].__package__]
+
+    for value in package.__dict__.values():
+        try:
+            is_sqla_factory = issubclass(value, SQLAlchemyModelFactory)
+        except TypeError:
+            is_sqla_factory = False
+
+        if is_sqla_factory:
+            yield value

--- a/bin/make_test
+++ b/bin/make_test
@@ -13,6 +13,9 @@ tempdir=$(mktemp -d)
 slug="test-project"
 cookiecutter . --directory "$1" --output-dir "$tempdir" --no-input slug="$slug" "${@:2}"
 cd "$tempdir"/"$slug"
+if [[ ! -v CI ]]; then
+  make services
+fi
 make -j sure
 cd -
 rm -rf "$tempdir"

--- a/pyapp/{{ cookiecutter.slug }}/tests/conftest.py
+++ b/pyapp/{{ cookiecutter.slug }}/tests/conftest.py
@@ -1,0 +1,1 @@
+../../../_shared/project/tests/conftest.py

--- a/pyapp/{{ cookiecutter.slug }}/tests/factories/__init__.py
+++ b/pyapp/{{ cookiecutter.slug }}/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/factories/__init__.py

--- a/pyapp/{{ cookiecutter.slug }}/tests/factories/factoryboy_sqlalchemy_session.py
+++ b/pyapp/{{ cookiecutter.slug }}/tests/factories/factoryboy_sqlalchemy_session.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/factories/factoryboy_sqlalchemy_session.py

--- a/pyapp/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/db.py
+++ b/pyapp/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/db.py
@@ -1,0 +1,1 @@
+../../../_shared/project/db.py

--- a/pypackage/{{ cookiecutter.slug }}/tests/factories/__init__.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/factories/__init__.py

--- a/pypackage/{{ cookiecutter.slug }}/tests/factories/factoryboy_sqlalchemy_session.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/factories/factoryboy_sqlalchemy_session.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/factories/factoryboy_sqlalchemy_session.py

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/conftest.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/conftest.py
@@ -1,0 +1,1 @@
+../../../_shared/project/tests/conftest.py

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/factories/__init__.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/factories/__init__.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/factories/__init__.py

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/factories/factoryboy_sqlalchemy_session.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/factories/factoryboy_sqlalchemy_session.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/factories/factoryboy_sqlalchemy_session.py

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/unit/conftest.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/unit/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from pyramid import testing
+from pyramid.request import apply_request_extensions
+
+
+@pytest.fixture
+def pyramid_config(pyramid_settings):
+    with testing.testConfig(settings=pyramid_settings) as pyramid_config:
+        yield pyramid_config
+
+
+@pytest.fixture
+def pyramid_request(
+{% if cookiecutter.get("postgres") == "yes" %}
+    db_session,
+{% endif %}
+    pyramid_config,  # pylint:disable=unused-argument
+):
+    pyramid_request = testing.DummyRequest()
+    apply_request_extensions(pyramid_request)
+{% if cookiecutter.get("postgres") == "yes" %}
+    pyramid_request.db = db_session
+{% endif %}
+    return pyramid_request

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/app_test.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/app_test.py
@@ -1,5 +1,3 @@
-from unittest.mock import sentinel
-
 from pyramid.router import Router
 
 from {{ cookiecutter.package_name }} import app
@@ -11,9 +9,9 @@ def test_create_app():
     assert isinstance(wsgi_app, Router)
 
 
-def test_index():
-    assert app.index(sentinel.request) == "Hello world!"
+def test_index(pyramid_request):
+    assert app.index(pyramid_request) == "Hello world!"
 
 
-def test_status():
-    assert app.status(sentinel.request) == {"status": "okay"}
+def test_status(pyramid_request):
+    assert app.status(pyramid_request) == {"status": "okay"}

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
@@ -1,9 +1,24 @@
+{% if cookiecutter.get("postgres") == "yes" %}
+from os import environ
+
+{% endif %}
 from pyramid.config import Configurator
 from pyramid.view import view_config
 
 
 def create_app(_=None, **settings):
     with Configurator(settings=settings) as config:
+{% if cookiecutter.get("postgres") == "yes" %}
+        config.registry.settings["database_url"] = environ["DATABASE_URL"]
+
+        config.registry.settings["tm.annotate_user"] = False
+        config.registry.settings["tm.manager_hook"] = "pyramid_tm.explicit_manager"
+        config.include("pyramid_tm")
+
+        config.include("{{ cookiecutter.package_name }}.models")
+        config.include("{{ cookiecutter.package_name }}.db")
+
+{% endif %}
         config.add_route("index", "/")
         config.add_route("status", "/_status")
 

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/db.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/db.py
@@ -1,0 +1,1 @@
+../../../_shared/project/db.py

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/models/__init__.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/models/__init__.py
@@ -1,0 +1,2 @@
+def includeme(_config):  # pragma: no cover
+    pass


### PR DESCRIPTION
The cookiecutter already has a `postgres` option that adds a bunch of DB stuff for projects, including: adding a postgres service to `docker-compose.yml`, adding a `make services` command, adding a `make db` command that upgrades the DB to the latest alembic migration, automatically creating the dev and test DBs, adding a postgres service to CI, creating the test DBs in CI, adding some of the requirements needed for a DB: `sqlalchemy`, `psycopg2` and `alembic`, adding envvars to `tox.ini` like `DATABASE_URL`, `SQLALCHEMY_SILENCE_UBER_WARNING`, and `ALEMBIC_CONFIG`, adding the `conf/alembic.ini` file, `env.py` file, and `script.py.mako` file, adding Docker Desktop to the prerequisites in `README.md`

But there's still some more DB-related stuff that projects need in order to be fully working. This PR adds everything that's missing to get a Pyramid app with fully working DB support in dev/prod and in CI/tests, including: a `db.py` file with an SQLAlchemy ORM `Base` class and code for automatically stamping the DB in dev and for getting an SQLAlchemy session and hooking it up to Pyramid requests with transaction management, the `pyramid-tm` and `zope.sqlalchemy` dependencies, required for Pyramid apps with a DB, code for hooking up `factory_boy` to the `sqlalchemy` session in the tests, code for creating an isolated DB session and transaction in the tests.

## How does this apply to Via?

Adding a DB to Via was the motivation for this cookiecutter PR. See <https://github.com/hypothesis/via/pull/1072> for a PR that applies these cookiecutter changes to Via, and <https://github.com/hypothesis/via/pull/1072> for a follow-up PR that uses Via's new DB stuff to add some DB-based code and tests.

## How does this apply to existing projects that already have a DB?

You can `cd` into any project and run `make template checkout=db` to see what changes this PR would make to that project. We have 5 existing projects that already use the cookiecutter's `postgres` option, I've created draft PRs showing what this PR would do to each of them:

* https://github.com/hypothesis/data-tasks/pull/23
* https://github.com/hypothesis/report/pull/266
* https://github.com/hypothesis/test-pypackage/pull/58
* https://github.com/hypothesis/test-pyramid-app/pull/117
* https://github.com/hypothesis/lms/pull/5564

## How does this apply to existing projects that don't use a DB?

This shouldn't make any changes to packages, apps or Pyramid apps that don't use a DB. For example:

```terminal
cd /tmp
git clone https://github.com/hypothesis/h-periodic.git
cd h-periodic
make template checkout=db
git diff
```

```terminal
cd /tmp
git clone https://github.com/hypothesis/h-matchers.git
cd h-matchers
make template checkout=db
git diff
```

We can use Via as an example of a cookiecutter-using Pyramid app that doesn't have a DB since Via's `main` branch doesn't have a DB enabled yet:

```terminal
cd /tmp
git clone https://github.com/hypothesis/via.git
cd via
make template checkout=db
git diff
```

## Testing

Create a new Pyramid app from this branch and with the `postgres` option enabled and have a look around:

```terminal
cd /tmp
cookiecutter gh:hypothesis/cookiecutters --directory pyramid-app --checkout db --no-input postgres=yes
cd my-pyramid-app
```

There's not much to test because the new app won't have any models or tables. But you can have a look around and try `make services`, `make sure`, `make sql` and `make shell`.

If you want to be able to actually test the DB stuff in action it's probably best to test the Via PR that actually adds a model, service and tests: https://github.com/hypothesis/via/pull/1072