### PR TITLE
Enable running `alembic` without `-c`

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -18,7 +18,7 @@ $(call help,make db,initialize the DB and upgrade it to the latest migration)
 db: args?=upgrade head
 db: python
 	@tox -qe dev --run-command 'python bin/make_db'
-	@tox -qe dev  --run-command 'alembic -c conf/alembic.ini $(args)'
+	@tox -qe dev  --run-command 'alembic $(args)'
 
 {% endif %}
 .PHONY: devdata

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -30,6 +30,7 @@ setenv =
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:{{ cookiecutter.slug }}}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
 {% if cookiecutter.get("postgres") == "yes" %}
+    dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
     SQLALCHEMY_SILENCE_UBER_WARNING=1
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/postgres}
     tests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_tests}


### PR DESCRIPTION
Move Alembic's config file path into an envvar in `tox.ini`. This enables you to run commands like:

    tox -e dev --run-command 'alembic upgrade head'

without having to type out the `-c conf/alembic.ini` argument every time.
