### PR TITLE
Fix `make template`

### DIFF
--- a/_shared/project/bin/make_template
+++ b/_shared/project/bin/make_template
@@ -12,7 +12,7 @@ with open(".cookiecutter/cookiecutter.json", "r", encoding="utf-8") as cookiecut
 
 extra_context = config.get("extra_context", {})
 extra_context["__ignore__"] = config.get("ignore", [])
-extra_context["__target_dir__"] = Path(os.getcwd())
+extra_context["__target_dir__"] = str(Path(os.getcwd()))
 
 parser = argparse.ArgumentParser(description="Update the project from the cookiecutter template")
 parser.add_argument("--template", help="the cookiecutter template to use (default: what's in cookiecutter.json)")


### PR DESCRIPTION
I'm getting `TypeError: Object of type PosixPath is not JSON serializable` when running `make template` in some of our projects. I'm not sure why it seems to affect some projects but not others, I think it probably depends on the project's default/first Python version, but for example:

```terminal
$ git clone https://github.com/hypothesis/h-matchers /tmp/h-matchers
$ cd /tmp/h-matchers
$ make template
...
TypeError: Object of type PosixPath is not JSON serializable
```