### PR TITLE
Fix `alembic.ini`

### DIFF
--- a/_shared/project/conf/alembic.ini
+++ b/_shared/project/conf/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
-script_location = {{ cookiecutter.slug }}/migrations
-database_url: postgresql://postgres@localhost:{{ cookiecutter.__postgres_port }}/postgres
+script_location = {{ cookiecutter.package_name }}/migrations
+sqlalchemy.url = postgresql://postgres@localhost:4433/postgres
 
 [loggers]
 keys = root,sqlalchemy,alembic


### PR DESCRIPTION
Fix a couple of bugs in the `alembic.ini` template:

1. `slug` (e.g. `test-pyramid-app`) is just wrong here, you want `package_name` (e.g. `test_pyramid_app`.

2. `database_url` doesn't work here: this is ready by alembic not by us and alembic looks for `sqlalchemy.url`.
