### PR TITLE
Add missing alembic config files

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -20,7 +20,13 @@ def remove_conditional_files():
     {% endif %}
 
     {% if cookiecutter.get("postgres") != "yes" %}
-    paths_to_remove.extend(["bin/create-db", "bin/make_db", "conf/alembic.ini"])
+    paths_to_remove.extend([
+        "bin/create-db",
+        "bin/make_db",
+        "conf/alembic.ini",
+        "{{ cookiecutter.package_name }}/migrations/env.py",
+        "{{ cookiecutter.package_name }}/migrations/script.py.mako",
+    ])
     {% endif %}
 
     {% if cookiecutter.get("devdata") != "yes" %}

--- a/_shared/project/migrations/env.py
+++ b/_shared/project/migrations/env.py
@@ -1,0 +1,70 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from {{ cookiecutter.package_name }}.db import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = Base.metadata
+compare_type = True
+compare_server_default = True
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+    url = config.get_main_option("database_url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/_shared/project/migrations/script.py.mako
+++ b/_shared/project/migrations/script.py.mako
@@ -1,0 +1,19 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/pyapp/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/env.py
+++ b/pyapp/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/env.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/migrations/env.py

--- a/pyapp/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/script.py.mako
+++ b/pyapp/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/script.py.mako
@@ -1,0 +1,1 @@
+../../../../_shared/project/migrations/script.py.mako

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/env.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/env.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/migrations/env.py

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/script.py.mako
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/migrations/script.py.mako
@@ -1,0 +1,1 @@
+../../../../_shared/project/migrations/script.py.mako


### PR DESCRIPTION
The cookiecutter generates an `alembic.ini` file and a `make db` command
that calls alembic, but it doesn't generate the `env.py` and
`script.py.mako` files that alembic needs in order to run.

This commit adds those two missing alembic config files. The files are
exactly as generated for us by `alembic init`.
