### PR TITLE
Ignore a `pkg_resources` deprecation warning

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -12,6 +12,7 @@ filterwarnings = [
     "error", # Fail the tests if there are any warnings.
     "ignore:^find_module\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
     "ignore:^FileFinder.find_loader\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",
+    "ignore:^pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
     "ignore:^pkg_resources is deprecated as an API:DeprecationWarning:pyramid",
     "ignore:^Deprecated call to .pkg_resources\\.declare_namespace\\('.*'\\).\\.:DeprecationWarning:pkg_resources",
     {% if include_exists("pytest/filterwarnings") %}


### PR DESCRIPTION
CI is failing for some of our projects without this, for example:

https://github.com/hypothesis/h-matchers/actions/runs/5495025656/jobs/10014153729
