### PR TITLE
Add `pytest-factoryboy` to the cookiecutter

### DIFF
--- a/_shared/project/requirements/functests.in
+++ b/_shared/project/requirements/functests.in
@@ -4,6 +4,7 @@ pip-sync-faster
 httpretty
 pytest
 factory-boy
+pytest-factoryboy
 h-matchers
 {% if cookiecutter.get("_directory") == "pyramid-app" %}
 webtest

--- a/_shared/project/requirements/tests.in
+++ b/_shared/project/requirements/tests.in
@@ -4,6 +4,7 @@ pip-sync-faster
 coverage[toml]
 pytest
 factory-boy
+pytest-factoryboy
 h-matchers
 httpretty
 freezegun

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -74,6 +74,7 @@ deps =
     lint,tests,coverage: coverage[toml]
     lint,tests,functests: pytest
     lint,tests,functests: factory-boy
+    lint,tests,functests: pytest-factoryboy
     lint,tests,functests: h-matchers
     lint,template: cookiecutter
 {% endif %}


### PR DESCRIPTION
h and LMS both have their own custom ways of integrating `factory_boy`
into `pytest` fixtures and they're both different from each other,
meanwhile our other projects don't have `factory_boy` integrated with
`pytest` at all.

There is an "official" `pytest` `factory_boy` implementation: the
`pytest-factoryboy` package from the `pytest-dev` GitHub repo:

https://github.com/pytest-dev/pytest-factoryboy

Let's just use this rather than inventing our own. We're already using
it in `gh-pr-upsert` (one of our command line tools).
