### PR TITLE
Set `factory_boy`'s random seed correctly

### DIFF
--- a/_shared/project/tests/pytest_plugins/factory_boy.py
+++ b/_shared/project/tests/pytest_plugins/factory_boy.py
@@ -1,0 +1,10 @@
+import factory.random
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def factory_boy_random_seed():
+    # Set factory_boy's random seed so that it produces the same random values
+    # in each run of the tests.
+    # See: https://factoryboy.readthedocs.io/en/latest/index.html#reproducible-random-values
+    factory.random.reseed_random("{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}")

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -29,6 +29,7 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:{{ cookiecutter.slug }}}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
+    tests,functests: PYTEST_PLUGINS = tests.pytest_plugins.factory_boy
 {% if cookiecutter.get("postgres") == "yes" %}
     SQLALCHEMY_SILENCE_UBER_WARNING=1
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/postgres}
@@ -131,7 +132,7 @@ commands =
     lint: pycodestyle src tests bin
 {% endif %}
     tests: coverage run -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
-    functests: pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
+    functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: -coverage combine
     coverage: coverage report
     template: python3 bin/make_template {posargs}

--- a/pyapp/{{ cookiecutter.slug }}/tests/pytest_plugins/factory_boy.py
+++ b/pyapp/{{ cookiecutter.slug }}/tests/pytest_plugins/factory_boy.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/pytest_plugins/factory_boy.py

--- a/pypackage/{{ cookiecutter.slug }}/tests/pytest_plugins/factory_boy.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/pytest_plugins/factory_boy.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/pytest_plugins/factory_boy.py

--- a/pyramid-app/{{ cookiecutter.slug }}/tests/pytest_plugins/factory_boy.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/tests/pytest_plugins/factory_boy.py
@@ -1,0 +1,1 @@
+../../../../_shared/project/tests/pytest_plugins/factory_boy.py


### PR DESCRIPTION
This is copy-pasted from some of our apps that already do this, but it
was missing from the cookiecutter so most of our projects don't do this
correctly.

This would normally go in `conftest.py` but I don't want the
cookiecutter to own that file: that would be a huge pain because
projects need to do a lot of per-project stuff in `conftest.py`. So
instead I'm having the cookiecutter add a pytest plugin to contain the
fixture. (We haven't run into this issue before because the cookiecutter
has never provided any pytest fixtures before.)
