### PR TITLE
Add DB, models, factories and transaction manager to `make shell`

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -166,7 +166,6 @@ def main():
             "package.json",
             "yarn.lock",
             ".docker.env",
-            "{{ cookiecutter.package_name }}/pshell.py",
             "tests/__init__.py",
             "tests/conftest.py",
             "tests/factories/__init__.py",

--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -60,6 +60,9 @@ omit = [
     {% if cookiecutter.get("_directory") == "pyapp" %}
     "*/{{ cookiecutter.package_name }}/app.py",
     {% endif %}
+    {% if cookiecutter.get("_directory") == "pyramid-app" %}
+    "{{ cookiecutter.package_name }}/pshell.py",
+    {% endif %}
     {% if include_exists("coverage/omit") %}
         {{- include("coverage/omit", indent=4) -}}
     {% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/pshell.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/pshell.py
@@ -1,2 +1,28 @@
-def setup(_env):  # pragma: no cover
-    return
+{% if cookiecutter.get("postgres") == "yes" %}
+from {{ cookiecutter.package_name }} import models
+{% endif %}
+from tests import factories
+{% if cookiecutter.get("postgres") == "yes" %}
+from tests.factories.factoryboy_sqlalchemy_session import (
+    set_factorboy_sqlalchemy_session,
+)
+{% endif %}
+
+
+def setup(env):
+{% if cookiecutter.get("postgres") == "yes" %}
+    env["tm"] = env["request"].tm
+    env["tm"].__doc__ = "Active transaction manager (a transaction is already begun)."
+
+    env["db"] = env["request"].db
+    env["db"].__doc__ = "Active DB session."
+
+    env["m"] = env["models"] = models
+    env["m"].__doc__ = "The {{ cookiecutter.package_name }}.models package."
+
+{% endif %}
+    env["f"] = env["factories"] = factories
+    env["f"].__doc__ = "The test factories for quickly creating objects."
+{% if cookiecutter.get("postgres") == "yes" %}
+    set_factorboy_sqlalchemy_session(env["request"].db)
+{% endif %}


### PR DESCRIPTION
Add handy `tm`, `db`, `m` / `models` and `f` / `factories` globals to `make shell` (`pshell`)'s Python environment.