### PR TITLE
Rename `TEST_DATABASE_URL` to just `DATABASE_URL`

### DIFF
--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -32,8 +32,8 @@ setenv =
 {% if cookiecutter.get("postgres") == "yes" %}
     SQLALCHEMY_SILENCE_UBER_WARNING=1
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/postgres}
-    tests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_tests}
-    functests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_functests}
+    tests: DATABASE_URL = {env:UNITTESTS_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_tests}
+    functests: DATABASE_URL = {env:FUNCTESTS_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_functests}
 {% endif %}
 {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
     # Make `import {{ cookiecutter.package_name }}` work in `make shell`.


### PR DESCRIPTION
Having the envvar be called `DATABASE_URL` in prod and dev but
`TEST_DATABASE_URL` in the tests is just a pain. For example in
functests the app code can crash when it tries to read `DATABASE_URL`
from the environment and this would have to be worked around somehow.

This still allows the user to override the `DATABASE_URL`'s in `tox.ini`
individually by setting `DATABASE_URL`, `UNITTESTS_DATABASE_URL` or
`FUNCTESTS_DATABASE_URL` in their shell (though I'm not sure why anyone
would want to do this), but `tox.ini` translates all three envvars into
`DATABASE_URL` before running the code.