### PR TITLE
Wait for healthchecks in `make services`

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -7,7 +7,7 @@ $(call help,make help,print this help message)
 .PHONY: services
 {% if has_services() %}
 $(call help,make services,start the services that the app needs)
-services: args?=up -d
+services: args?=up -d --wait
 services: python
 	@docker compose $(args)
 {% endif %}


### PR DESCRIPTION
This enables starting apps with `make services dev` without potentially running into errors from the app due to services not being ready when the web server tries to connect.

Services must define a healthcheck [1] in `docker-compose.yml` for this to work.

The `--wait` flag is missing from the Docker Compose docs, but see https://github.com/docker/compose/pull/8777.

[1] https://docs.docker.com/compose/compose-file/05-services/#healthcheck