### PR TITLE
Simplify alembic DB URL configuration

### DIFF
--- a/_shared/project/conf/alembic.ini
+++ b/_shared/project/conf/alembic.ini
@@ -1,6 +1,5 @@
 [alembic]
 script_location = {{ cookiecutter.package_name }}/migrations
-sqlalchemy.url = postgresql://postgres@localhost:{{ cookiecutter.__postgres_port }}/postgres
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/_shared/project/migrations/env.py
+++ b/_shared/project/migrations/env.py
@@ -1,3 +1,4 @@
+import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -33,9 +34,8 @@ def run_migrations_offline() -> None:
     Calls to context.execute() here emit the given string to the
     script output.
     """
-    url = config.get_main_option("database_url")
     context.configure(
-        url=url,
+        url=os.environ["DATABASE_URL"],
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -55,6 +55,7 @@ def run_migrations_online() -> None:
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        url=os.environ["DATABASE_URL"],
     )
 
     with connectable.connect() as connection:


### PR DESCRIPTION
Always read it from the `DATABASE_URL` environment variable.

This works on the local environment (where the env var is set by tox) and in EBS (environment variable also set there).