### PR TITLE
Remove `bin/make_db` from the `pyapp` cookiecutter

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -12,7 +12,7 @@ services: python
 	@docker compose $(args)
 {% endif %}
 
-{% if cookiecutter.get("postgres") == "yes" %}
+{% if cookiecutter.get("_directory") == "pyramid-app" and cookiecutter.get("postgres") == "yes" %}
 .PHONY: db
 $(call help,make db,initialize the DB and upgrade it to the latest migration)
 db: args?=upgrade head

--- a/_shared/project/bin/make_db
+++ b/_shared/project/bin/make_db
@@ -1,5 +1,0 @@
-"""Initialize the dev environment's DB."""
-#!/usr/bin/env python3
-import sys
-from pyramid.paster import bootstrap
-bootstrap("conf/development.ini")

--- a/pyapp/{{ cookiecutter.slug }}/bin/make_db
+++ b/pyapp/{{ cookiecutter.slug }}/bin/make_db
@@ -1,1 +1,0 @@
-../../../_shared/project/bin/make_db

--- a/pyramid-app/{{ cookiecutter.slug }}/bin/make_db
+++ b/pyramid-app/{{ cookiecutter.slug }}/bin/make_db
@@ -1,1 +1,5 @@
-../../../_shared/project/bin/make_db
+"""Initialize the dev environment's DB."""
+#!/usr/bin/env python3
+import sys
+from pyramid.paster import bootstrap
+bootstrap("conf/development.ini")


### PR DESCRIPTION
This script contains Pyramid stuff, it only works in Pyramid apps. I think we might actually want a `make db` for non-Pyramid apps as well but it'll have to be different.
