### PR TITLE
Fix `make db` and add schema creation and auto-stamping

### DIFF
--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -24,6 +24,8 @@ def remove_conditional_files():
         "bin/create-db",
         "bin/make_db",
         "conf/alembic.ini",
+        "{{ cookiecutter.package_name }}/db.py",
+        "{{ cookiecutter.package_name }}/models/__init__.py",
         "{{ cookiecutter.package_name }}/migrations/env.py",
         "{{ cookiecutter.package_name }}/migrations/script.py.mako",
     ])
@@ -150,6 +152,8 @@ def main():
         template_ignore_patterns.extend([
             "{{ cookiecutter.package_name }}/__init__.py",
             "{{ cookiecutter.package_name }}/app.py",
+            "{{ cookiecutter.package_name }}/db.py",
+            "{{ cookiecutter.package_name }}/models/__init__.py",
             "Dockerfile",
             "package.json",
             "yarn.lock",

--- a/_shared/project/conf/supervisord-dev.conf
+++ b/_shared/project/conf/supervisord-dev.conf
@@ -19,6 +19,9 @@ silent=true
 {{ program(program_name, program_settings) }}
 {% endfor %}
 {% else %}
+{% if cookiecutter._directory == "pyramid-app" and cookiecutter.get("postgres") == "yes" %}
+{{ program("make_db", {"command": "bin/make_db", "startsecs": "0"}) }}
+{% endif %}
 {% if cookiecutter._directory == "pyramid-app" %}
 {{ program("web", {"command": "gunicorn --bind :" + cookiecutter.port + " --workers 1 --reload --timeout 0 --paste conf/development.ini"}) }}
 {% else %}

--- a/_shared/project/requirements/prod.in
+++ b/_shared/project/requirements/prod.in
@@ -8,6 +8,10 @@ sqlalchemy
 psycopg2
 alembic
 {% endif %}
+{% if cookiecutter.get("_directory") == "pyramid-app" and cookiecutter.get("postgres") == "yes" %}
+pyramid-tm
+zope.sqlalchemy
+{% endif %}
 {% if include_exists("requirements/prod.in") %}
     {{- include("requirements/prod.in") -}}
 {% endif %}

--- a/pyramid-app/{{ cookiecutter.slug }}/bin/make_db
+++ b/pyramid-app/{{ cookiecutter.slug }}/bin/make_db
@@ -1,5 +1,35 @@
-"""Initialize the dev environment's DB."""
 #!/usr/bin/env python3
-import sys
+"""Initialize the dev environment's DB."""
+import alembic.command
+import alembic.config
 from pyramid.paster import bootstrap
-bootstrap("conf/development.ini")
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+
+from {{ cookiecutter.package_name }}.db import Base, create_engine
+
+
+def is_stamped(engine) -> bool:
+    """Return True if the DB is stamped with an Alembic revision ID."""
+    with engine.connect() as connection:
+        try:
+            if connection.execute(text("select * from alembic_version")).first():
+                return True
+        except ProgrammingError:
+            pass
+
+    return False
+
+
+def main():
+    with bootstrap("conf/development.ini") as env:
+        settings = env["registry"].settings
+        engine = create_engine(settings)
+
+        if not is_stamped(engine):
+            Base.metadata.create_all(engine)
+            alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
@@ -1,9 +1,20 @@
+from os import environ
+
 from pyramid.config import Configurator
 from pyramid.view import view_config
 
 
 def create_app(_=None, **settings):
     with Configurator(settings=settings) as config:
+        config.registry.settings["database_url"] = environ["DATABASE_URL"]
+
+        config.registry.settings["tm.annotate_user"] = False
+        config.registry.settings["tm.manager_hook"] = "pyramid_tm.explicit_manager"
+        config.include("pyramid_tm")
+
+        config.include("{{ cookiecutter.package_name }}.models")
+        config.include("{{ cookiecutter.package_name }}.db")
+
         config.add_route("index", "/")
         config.add_route("status", "/_status")
 

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/db.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/db.py
@@ -1,0 +1,40 @@
+import sqlalchemy
+import zope.sqlalchemy
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, Session
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix_%(column_0_N_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_N_name)s_%(referred_table_name)s_%(referred_column_0_N_name)s",
+            "pk": "pk_%(table_name)s",
+        }
+    )
+
+
+def create_engine(settings):  # pragma: no cover
+    """Return a SQLAlchemy engine."""
+    return sqlalchemy.create_engine(settings["database_url"])
+
+
+def includeme(config):  # pragma: no cover
+    engine = create_engine(config.registry.settings)
+
+    def db_session(request):
+        """Return the SQLAlchemy session for the given request."""
+        session = Session(engine, info={"request": request})
+
+        # Register the session with pyramid_tm/transaction so that they'll
+        # create a new DB transaction for each request and close the session at
+        # the end of the request.
+        zope.sqlalchemy.register(session, transaction_manager=request.tm)
+
+        return session
+
+    # Make the SQLAlchemy session available as `request.db`.
+    # `reify=True` means it'll create only one session per request.
+    config.add_request_method(db_session, name="db", reify=True)

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/models/__init__.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/models/__init__.py
@@ -1,0 +1,2 @@
+def includeme(_config):  # pragma: no cover
+    pass


### PR DESCRIPTION
Depends on https://github.com/hypothesis/cookiecutters/pull/146

This is needed in order to make `make template` clean in Via following changes that were made in https://github.com/hypothesis/via/pull/1123.

The `make db` command currently crashes in newly-generated projects because the cookiecutter's `env.py` (for alembic) tries to import `db.py` which doesn't exist (since the cookiecutter doesn't generate this file).
    
This commit adds the necessary new lines and files to the cookiecutter to have a working `make db` command that creates database tables that don't already exist and that stamps the DB with the latest alembic revision if it isn't already stamped.
    
A process is added to `make dev` to automatically run `make db` when `make dev` is run so that the DB schema gets created and the alembic revision stamped when you run `make dev`.
