### PR TITLE
Fix alembic autogeneration

### DIFF
--- a/_shared/project/migrations/env.py
+++ b/_shared/project/migrations/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from {{ cookiecutter.package_name }} import models
 from {{ cookiecutter.package_name }}.db import Base
 
 # this is the Alembic Config object, which provides


### PR DESCRIPTION
We need to import `models` in `env.py` in order for alembic's autogeneration to work properly, see https://github.com/hypothesis/via/pull/1133
