### PR TITLE
Remove SQLALCHEMY_SILENCE_UBER_WARNING env variable

### DIFF
--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -32,7 +32,6 @@ setenv =
     tests,functests: PYTEST_PLUGINS = tests.pytest_plugins.factory_boy
 {% if cookiecutter.get("postgres") == "yes" %}
     dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
-    SQLALCHEMY_SILENCE_UBER_WARNING=1
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/postgres}
     tests: DATABASE_URL = {env:UNITTESTS_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_tests}
     functests: DATABASE_URL = {env:FUNCTESTS_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_functests}


### PR DESCRIPTION
Not necessary in SQLA 2.0 and it might hide some issues with the upgrades.