### PR TITLE
Enable PYTHONDEVMODE in the dev server and tests

### DIFF
--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -29,6 +29,7 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:{{ cookiecutter.slug }}}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
+    dev,tests,functests: PYTHONDEVMODE = {env:PYTHONDEVMODE:1}
     tests,functests: PYTEST_PLUGINS = tests.pytest_plugins.factory_boy
 {% if cookiecutter.get("postgres") == "yes" %}
     dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}


### PR DESCRIPTION
From https://docs.python.org/3/library/devmode.html#devmode

More generally, try to run your tests in the Python Development Mode which helps to prepare your code to make it
compatible with the next Python version.