### PR TITLE
Run CI when the python version changes

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ on:
       - '.docker.env'
 {% endif %}
       - '**/.gitignore'
-      - '.python-version'
 {% if cookiecutter.get("docker") == "yes" %}
       - 'Dockerfile'
 {% endif %}


### PR DESCRIPTION
Is this actually used in CI? Or only the version in the docker file matters?

In any case I reckon this changes so rarely that it's not worth any misunderstandings.