### PR TITLE
Don't call `ci.yml` from `deploy.yml`

### DIFF
--- a/_shared/project/.github/workflows/deploy.yml
+++ b/_shared/project/.github/workflows/deploy.yml
@@ -26,12 +26,8 @@ on:
       - 'docker-compose.yml'
       - 'tox.ini'
 jobs:
-  ci:
-    name: CI
-    uses: ./.github/workflows/ci.yml
   docker_hub:
     name: Docker Hub
-    needs: [ci]
     uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
     with:
       Application: {% raw %}${{ github.event.repository.name }}{% endraw +%}


### PR DESCRIPTION
This has been discussed a couple of times in Slack. Reasons for doing this:

* Having `deploy.yml` call `ci.yml` makes deploys take much longer (for some of our apps it adds several minutes to the time taken to deploy). Developers are waiting around for this
* This is particularly egregious when deploying a lot of Dependabot PRs, or deploying a lot of separate small PRs
* It's also particularly egregious when trying to quickly deploy a hot-fix for a problem in production, it slows us down
* It also means that flakey tests can cause deployments to fail
* CI should already have passed on the PR before it was merged. Technically it's possible that CI could pass on a PR but then fail on `main` after that PR is merged if the PR branch wasn't up to date with `main`, but that's very rare (I don't think I've ever seen it)
* We already run `ci.yml` on `main` as a separate job (not part of `deploy.yml`) after merging a PR (or after pushing directly to `main`), and if this CI run on `main` fails we get a Slack notification. This won't block the deployment (it's a separate, parallel workflow run) but it will let us know if there's a problem