### PR TITLE
Various improvements to the cookiecutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - name: Install Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -22,10 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - name: Install Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.7'
       - run: python -m pip install cookiecutter 'tox<4'
       - name: Configure git
         run: |

--- a/_shared/project/.github/dependabot.yml
+++ b/_shared/project/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
+{% if include_exists(".github/dependabot/pip/tail.yml") %}
+  {{- include(".github/dependabot/pip/tail.yml", indent=2) -}}
+{% endif %}
 {% if cookiecutter.get("frontend") == "yes" %}
 - package-ecosystem: "npm"
   directory: "/"
@@ -15,6 +18,9 @@ updates:
     day: "sunday"
     time: "00:00"
     timezone: "Europe/London"
+{% if include_exists(".github/dependabot/npm/tail.yml") %}
+  {{- include(".github/dependabot/npm/tail.yml", indent=2) -}}
+{% endif %}
 {% endif %}
 {% if cookiecutter.get("docker") == "yes" %}
 - package-ecosystem: "docker"
@@ -28,4 +34,7 @@ updates:
     # Only send PRs for patch versions of Python.
     - dependency-name: "python"
       update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+{% if include_exists(".github/dependabot/docker/tail.yml") %}
+  {{- include(".github/dependabot/docker/tail.yml", indent=2) -}}
+{% endif %}
 {% endif %}

--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     {% if job == 'coverage' %}
     needs: tests
     {% endif %}
-    runs-on: ubuntu-latest
+    runs-on: {{ cookiecutter["__" + job + "_runner_type"] }}
     {% if job in ["tests", "functests"] and has_services() %}
     services:
       {% if cookiecutter.get("postgres") == "yes" %}
@@ -110,6 +110,10 @@ jobs:
       - run: tox -e checkformatting
       {% else %}
       - run: tox -e {{ job }}
+      {% if job == 'tests' %}
+        env:
+          COVERAGE_FILE: .coverage.{% raw %}${{ matrix.python-version }}{% endraw +%}
+      {% endif %}
       {% endif %}
       {% if job == 'tests' %}
       - name: Upload coverage file

--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -89,9 +89,7 @@ jobs = 0 # Use one process for CPU.
 load-plugins = [
     "pylint.extensions.bad_builtin",
     "pylint.extensions.check_elif",
-    "pylint.extensions.comparetozero",
     "pylint.extensions.docparams",
-    "pylint.extensions.emptystring",
     "pylint.extensions.mccabe",
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.redefined_variable_type",
@@ -116,6 +114,8 @@ enable = [
     "deprecated-pragma",
     "useless-suppression",
     "use-symbolic-message-instead",
+    "use-implicit-booleaness-not-comparison-to-zero",
+    "use-implicit-booleaness-not-comparison-to-string",
     {% if include_exists("pylint/enables") %}
         {{- include("pylint/enables", indent=4) -}}
     {% endif %}

--- a/_shared/project/requirements/functests.in
+++ b/_shared/project/requirements/functests.in
@@ -9,6 +9,9 @@ h-matchers
 {% if cookiecutter.get("_directory") == "pyramid-app" %}
 webtest
 {% endif %}
+{% if cookiecutter.get("__parallel_unit_tests") and cookiecutter.get("postgres") == "yes" %}
+filelock
+{% endif %}
 {% if include_exists("requirements/functests.in") %}
     {{- include("requirements/functests.in") -}}
 {% endif %}

--- a/_shared/project/requirements/lint.in
+++ b/_shared/project/requirements/lint.in
@@ -3,7 +3,7 @@ pip-sync-faster
 -r tests.txt
 -r functests.txt
 toml # Needed for pydocstyle to support pyproject.toml.
-pylint
+pylint>=3.0.0
 pydocstyle
 pycodestyle
 {% if include_exists("requirements/lint.in") %}

--- a/_shared/project/requirements/tests.in
+++ b/_shared/project/requirements/tests.in
@@ -1,8 +1,14 @@
 pip-tools
 pip-sync-faster
 -r prod.txt
-coverage[toml]
 pytest
+pytest-coverage
+{% if cookiecutter.get("__parallel_unit_tests") %}
+pytest-xdist[psutil]
+{% if cookiecutter.get("postgres") == "yes" %}
+filelock
+{% endif %}
+{% endif %}
 factory-boy
 pytest-factoryboy
 h-matchers

--- a/_shared/project/setup.cfg
+++ b/_shared/project/setup.cfg
@@ -19,7 +19,6 @@ package_dir =
 packages = find:
 python_requires = >={{ python_versions()|oldest|pyformat(PyFormats.MAJOR_DOT_MINOR_FMT) }}
 install_requires =
-    importlib_metadata;python_version<"3.8."
 {% if cookiecutter.get("postgres") == "yes" %}
     sqlalchemy
     psycopg2

--- a/_shared/project/tests/pyproject.toml
+++ b/_shared/project/tests/pyproject.toml
@@ -4,9 +4,7 @@ jobs = 0 # Use one process for CPU.
 load-plugins = [
     "pylint.extensions.bad_builtin",
     "pylint.extensions.check_elif",
-    "pylint.extensions.comparetozero",
     "pylint.extensions.docparams",
-    "pylint.extensions.emptystring",
     "pylint.extensions.mccabe",
     "pylint.extensions.overlapping_exceptions",
     "pylint.extensions.redefined_variable_type",
@@ -31,6 +29,8 @@ enable = [
     "deprecated-pragma",
     "useless-suppression",
     "use-symbolic-message-instead",
+    "use-implicit-booleaness-not-comparison-to-zero",
+    "use-implicit-booleaness-not-comparison-to-string",
     {% if include_exists("tests/pylint/enables") %}
         {{- include("tests/pylint/enables", indent=4) -}}
     {% endif %}

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -31,6 +31,7 @@ setenv =
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
     dev,tests,functests: PYTHONDEVMODE = {env:PYTHONDEVMODE:1}
     tests,functests: PYTEST_PLUGINS = tests.pytest_plugins.factory_boy
+    tests: COVERAGE_FILE = {env:COVERAGE_FILE:.coverage.{envname}}
 {% if cookiecutter.get("postgres") == "yes" %}
     dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}
     dev: DATABASE_URL = {env:DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/postgres}
@@ -69,12 +70,13 @@ deps =
     format,checkformatting: black
     format,checkformatting: isort
     lint: toml
-    lint: pylint
+    lint: pylint>=3.0.0
     lint: pydocstyle
     lint: pycodestyle
     lint,tests: pytest-mock
-    lint,tests,coverage: coverage[toml]
     lint,tests,functests: pytest
+    tests: pytest-coverage
+    coverage: coverage[toml]
     lint,tests,functests: factory-boy
     lint,tests,functests: pytest-factoryboy
     lint,tests,functests: h-matchers
@@ -133,9 +135,9 @@ commands =
     lint: pydocstyle src tests bin
     lint: pycodestyle src tests bin
 {% endif %}
-    tests: coverage run -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
+    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 {%- if cookiecutter.get("__parallel_unit_tests") %} --numprocesses logical {%- endif %} --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
     functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
-    coverage: -coverage combine
+    coverage: coverage combine
     coverage: coverage report
     template: python3 bin/make_template {posargs}
     {% if include_exists("tox/commands") %}

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -25,5 +25,11 @@
     "__hdev_project_type": "application",
     "__ignore__": "",
     "__target_dir__": "",
-    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
+    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true},
+    "__parallel_unit_tests": false,
+    "__format_runner_type": "ubuntu-latest",
+    "__lint_runner_type": "ubuntu-latest",
+    "__tests_runner_type": "ubuntu-latest",
+    "__coverage_runner_type": "ubuntu-latest",
+    "__functests_runner_type": "ubuntu-latest"
 }

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -3,7 +3,7 @@
     "package_name": "{{ cookiecutter.name.lower().replace(' ', '_').replace('-', '_') }}",
     "slug": "{{ cookiecutter.package_name.replace('_', '-') }}",
     "short_description": "A Python app.",
-    "python_version": "3.10.6",
+    "python_version": "3.12.0",
     "github_owner": "hypothesis",
     "visibility": ["public", "private"],
     "create_github_repo": ["no", "yes"],

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -24,5 +24,11 @@
     "__hdev_project_type": "library",
     "__ignore__": "",
     "__target_dir__": "",
-    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
+    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true},
+    "__parallel_unit_tests": false,
+    "__format_runner_type": "ubuntu-latest",
+    "__lint_runner_type": "ubuntu-latest",
+    "__tests_runner_type": "ubuntu-latest",
+    "__coverage_runner_type": "ubuntu-latest",
+    "__functests_runner_type": "ubuntu-latest"
 }

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -3,7 +3,7 @@
     "package_name": "{{ cookiecutter.name.lower().replace(' ', '_').replace('-', '_') }}",
     "slug": "{{ cookiecutter.package_name.replace('_', '-') }}",
     "short_description": "An installable Python package.",
-    "python_versions": "3.10.6, 3.9.13, 3.8.13, 3.7.13",
+    "python_versions": "3.12.0, 3.11.6, 3.10.13, 3.9.18, 3.8.18",
     "github_owner": "hypothesis",
     "copyright_holder": "Hypothesis",
     "visibility": ["public", "private"],

--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
@@ -1,9 +1,5 @@
 from argparse import ArgumentParser
-
-try:
-    from importlib.metadata import version
-except ModuleNotFoundError:
-    from importlib_metadata import version
+from importlib.metadata import version
 
 
 def cli(_argv=None):  # pylint:disable=inconsistent-return-statements

--- a/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
@@ -1,11 +1,8 @@
+from importlib.metadata import version
+
 import pytest
 
 from {{ cookiecutter.package_name }}.cli import cli
-
-try:
-    from importlib.metadata import version
-except ModuleNotFoundError:
-    from importlib_metadata import version
 
 
 def test_it():

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -28,5 +28,11 @@
     "__ignore__": "",
     "__target_dir__": "",
     "__copyright_year": "2022",
-    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
+    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true},
+    "__parallel_unit_tests": false,
+    "__format_runner_type": "ubuntu-latest",
+    "__lint_runner_type": "ubuntu-latest",
+    "__tests_runner_type": "ubuntu-latest",
+    "__coverage_runner_type": "ubuntu-latest",
+    "__functests_runner_type": "ubuntu-latest"
 }

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -3,7 +3,7 @@
     "package_name": "{{ cookiecutter.name.lower().replace(' ', '_').replace('-', '_') }}",
     "slug": "{{ cookiecutter.package_name.replace('_', '-') }}",
     "short_description": "A web app written using the Pyramid framework.",
-    "python_version": "3.10.6",
+    "python_version": "3.10.13",
     "port": "{{ random_port_number() }}",
     "github_owner": "hypothesis",
     "visibility": ["public", "private"],


### PR DESCRIPTION
* Add support for per-project customisation of Dependabot groups
* Add support for per-project customisation of GitHub Actions runner types
* Add support for (optionally) running a project's unit tests in parallel
* Upgrade to pylint 3.0
* Update the Python versions used by default for new projects (and in the cookiecutter's tests)

Test PRs:

* https://github.com/hypothesis/test-pypackage/pull/63
* https://github.com/hypothesis/test-pyapp/pull/86
* https://github.com/hypothesis/test-pyramid-app/pull/143
* https://github.com/hypothesis/lms/pull/5736