### PR TITLE
Fix pytest-cov requirement

### DIFF
--- a/_shared/project/requirements/tests.in
+++ b/_shared/project/requirements/tests.in
@@ -2,7 +2,7 @@ pip-tools
 pip-sync-faster
 -r prod.txt
 pytest
-pytest-coverage
+pytest-cov
 {% if cookiecutter.get("__parallel_unit_tests") %}
 pytest-xdist[psutil]
 {% if cookiecutter.get("postgres") == "yes" %}

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -75,7 +75,7 @@ deps =
     lint: pycodestyle
     lint,tests: pytest-mock
     lint,tests,functests: pytest
-    tests: pytest-coverage
+    tests: pytest-cov
     coverage: coverage[toml]
     lint,tests,functests: factory-boy
     lint,tests,functests: pytest-factoryboy


### PR DESCRIPTION
Oops, the library is called `pytest-cov` not `pytest-coverage`.
