### PR TITLE
Fix the `--version` option

### DIFF
--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
@@ -4,10 +4,11 @@ from importlib.metadata import version
 
 def cli(_argv=None):  # pylint:disable=inconsistent-return-statements
     parser = ArgumentParser()
-    parser.add_argument("-v", "--version", action="store_true")
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=version("{{ cookiecutter.slug }}"),
+    )
 
     args = parser.parse_args(_argv)
-
-    if args.version:
-        print(version("{{ cookiecutter.slug }}"))
-        return 0

--- a/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
+++ b/pypackage/{{ cookiecutter.slug }}/src/{{ cookiecutter.package_name }}/cli.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 from importlib.metadata import version
 
 
-def cli(_argv=None):  # pylint:disable=inconsistent-return-statements
+def cli(argv=None):
     parser = ArgumentParser()
     parser.add_argument(
         "-v",
@@ -11,4 +11,4 @@ def cli(_argv=None):  # pylint:disable=inconsistent-return-statements
         version=version("{{ cookiecutter.slug }}"),
     )
 
-    args = parser.parse_args(_argv)
+    _args = parser.parse_args(argv)

--- a/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
+++ b/pypackage/{{ cookiecutter.slug }}/tests/unit/{{ cookiecutter.package_name }}/cli_test.py
@@ -17,7 +17,8 @@ def test_help():
 
 
 def test_version(capsys):
-    exit_code = cli(["--version"])
+    with pytest.raises(SystemExit) as exc_info:
+        cli(["--version"])
 
     assert capsys.readouterr().out.strip() == version("{{ cookiecutter.slug }}")
-    assert not exit_code
+    assert not exc_info.value.code


### PR DESCRIPTION
The `--version` option as implemented doesn't work with required arguments. This is how you're supposed to do it.

Testing
-------

**CI**: CI in the cookiecutter's repo actually generates a new package with a CLI using the cookiecutter and runs the unit and functests that the cookiecutter generates for the new package, which include both unit and functests for `--version` so this is tested on CI. (It also runs the new package's `lint` and `checkformatting`.)

**Local:** Running `make sure` in the cookiecutter's repo will do the same tests locally as CI.

**Manually:**

```terminal
cookiecutter gh:hypothesis/cookiecutters --output-dir /tmp/testing --directory pypackage --checkout fix--version-option --no-input console_script=yes
cd /tmp/testing/my-python-package
tox -e dev --run-command 'my-python-package --version'
```