### PR TITLE
Reorganise the cookiecutter's Gunicorn config

### DIFF
--- a/_shared/project/conf/supervisord-dev.conf
+++ b/_shared/project/conf/supervisord-dev.conf
@@ -23,7 +23,7 @@ silent=true
 {{ program("make_db", {"command": "bin/make_db", "startsecs": "0"}) }}
 {% endif %}
 {% if cookiecutter._directory == "pyramid-app" %}
-{{ program("web", {"command": "gunicorn --bind :" + cookiecutter.port + " --workers 1 --reload --timeout 0 --paste conf/development.ini"}) }}
+{{ program("web", {"command": "newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py"}) }}
 {% else %}
 {{ program("app", {"command": "python3 -m " + cookiecutter.package_name}) }}
 {% endif %}

--- a/_shared/project/conf/supervisord.conf
+++ b/_shared/project/conf/supervisord.conf
@@ -22,7 +22,7 @@ logfile_maxbytes=0
 {% endfor %}
 {% else %}
 {% if cookiecutter._directory == "pyramid-app" %}
-{{ program("web", {"command": "newrelic-admin run-program gunicorn --paste conf/production.ini --bind 0.0.0.0:" + cookiecutter.port}) }}
+{{ program("web", {"command": "newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py" }) }}
 {% else %}
 {{ program("app", {"command": "python3 -m " + cookiecutter.package_name}) }}
 {% endif %}

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -34,5 +34,6 @@
     "__lint_runner_type": "ubuntu-latest",
     "__tests_runner_type": "ubuntu-latest",
     "__coverage_runner_type": "ubuntu-latest",
-    "__functests_runner_type": "ubuntu-latest"
+    "__functests_runner_type": "ubuntu-latest",
+    "__gunicorn_bind": false
 }

--- a/pyramid-app/{{ cookiecutter.slug }}/conf/gunicorn-dev.conf.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/conf/gunicorn-dev.conf.py
@@ -1,0 +1,4 @@
+bind = "0.0.0.0:{{ cookiecutter.port }}"
+reload = True
+reload_extra_files = "{{ cookiecutter.package_name }}/templates"
+timeout = 0

--- a/pyramid-app/{{ cookiecutter.slug }}/conf/gunicorn.conf.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/conf/gunicorn.conf.py
@@ -1,0 +1,2 @@
+bind = "{{ cookiecutter.get("__gunicorn_bind") or "0.0.0.0:" + cookiecutter.port }}"
+worker_tmp_dir = "/dev/shm"

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/app.py
@@ -1,11 +1,14 @@
+{% if cookiecutter.get("postgres") == "yes" %}
 from os import environ
 
+{% endif %}
 from pyramid.config import Configurator
 from pyramid.view import view_config
 
 
 def create_app(_=None, **settings):
     with Configurator(settings=settings) as config:
+        {% if cookiecutter.get("postgres") == "yes" %}
         config.registry.settings["database_url"] = environ["DATABASE_URL"]
 
         config.registry.settings["tm.annotate_user"] = False
@@ -15,6 +18,7 @@ def create_app(_=None, **settings):
         config.include("{{ cookiecutter.package_name }}.models")
         config.include("{{ cookiecutter.package_name }}.db")
 
+        {% endif %}
         config.add_route("index", "/")
         config.add_route("status", "/_status")
 


### PR DESCRIPTION
This commit reorganise's the Gunicorn configuration in the cookiecutter
to make it match with the config reorganisation that I've recently done
in all the apps:

https://github.com/hypothesis/lms/pull/5986
https://github.com/hypothesis/checkmate/pull/787
https://github.com/hypothesis/via/pull/1262
https://github.com/hypothesis/bouncer/pull/702
https://github.com/hypothesis/test-pyramid-app/pull/164
https://github.com/hypothesis/h/pull/8407
https://github.com/hypothesis/h/pull/8416
