### PR TITLE
Notify in Slack on failed deploys

### DIFF
--- a/_shared/project/.github/workflows/slack.yml
+++ b/_shared/project/.github/workflows/slack.yml
@@ -1,7 +1,7 @@
 name: Slack
 on:
   workflow_run:
-    workflows: [CI]
+    workflows: [CI{% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}, Deploy{% endif %}]
     types: [completed]
     branches: [main]
 jobs:


### PR DESCRIPTION
Post a notification into the `#prod-general` channel in Slack if the
`deploy.yml` workflow fails on the `main` branch.
