### PR TITLE
Post to Slack when cookiecutter workflows fail

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,18 @@
+name: Slack
+on:
+  workflow_run:
+    workflows: [CI, Update repos]
+    types: [completed]
+    branches: [main]
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: 'C4K6M7P5E'
+          slack-message: "A workflow run failed\n*Repo:* `${{ github.event.repository.full_name }}` (${{ github.event.repository.html_url }})\n*Workflow:* ${{ github.event.workflow.name }} (${{ github.event.workflow.html_url }})\n*Branch:* `${{ github.event.workflow_run.head_branch }}`\n*Commit:* `${{ github.event.workflow_run.head_commit.id }}`\n*Run:* ${{ github.event.workflow_run.html_url }}\n*Conclusion:* ${{ github.event.workflow_run.conclusion }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This is the same as what we do in other repos. The **Update repos** workflow had failed three months in a row and no one had noticed, so it seems worth adding this to Slack.