### PR TITLE
Typecheck the bodies of untyped functions

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -177,6 +177,7 @@ score = "no"
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+check_untyped_defs = true
 
 disable_error_code = [
     # https://mypy.readthedocs.io/en/stable/error_code_list.html#code-import-untyped


### PR DESCRIPTION
Via is getting a warning (not an error) from mypy:

    via/services/__init__.py:79: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]

The warning seems to happen when a function has no type annotations in
its signature but some type annotations in its body (for local
variables).

I don't see why we wouldn't want to typecheck the bodies of functions?
Is there a reason mypy disables this by default?
