### PR TITLE
Make some tweaks to the mypy config

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -174,6 +174,9 @@ output-format = "colorized"
 score = "no"
 
 [tool.mypy]
+allow_untyped_globals = true
+error_summary = false
+pretty = true
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
`allow_untyped_globals = true`: so that mypy allows global and class
variables without type annotations.

`error_summary=false`: so that mypy doesn't print a summary line
(stating the number of error messages) after printing the error
messages. We just need to see the error messages. This also means that
if there are no error message `make typecheck` prints nothing, which
reduces unnecessary output noise and is consistent with our other
commands.

`pretty=true`: makes the error messages more friendly and informative.
