### PR TITLE
Revert "Typecheck the bodies of untyped functions"

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -180,7 +180,6 @@ pretty = true
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-check_untyped_defs = true
 
 disable_error_code = [
     # https://mypy.readthedocs.io/en/stable/error_code_list.html#code-import-untyped


### PR DESCRIPTION
Reverts hypothesis/cookiecutters#176. Reverting this for now as I think it might be the cause of new typechecking errors in a lot of our projects, which I don't want to deal with right now. Perhaps we can try this again later, perhaps on a project-by-project basis.