### PR TITLE
Pin GHA's upload-artifact to 3.1.3

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       {% endif %}
       {% if job == 'tests' %}
       - name: Upload coverage file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: coverage
           path: .coverage.*


### PR DESCRIPTION
As a temporary workaround for the changes newer versions (>3.2.0) around not uploading hidden files


See: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1725285976308269