### PR TITLE
Enable `include-hidden-files` option for coverage upload

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           name: coverage
           path: .coverage.*
+          include-hidden-files: true
       {% endif %}
   {% endfor %}
   {% if cookiecutter.get("frontend") == "yes" %}


### PR DESCRIPTION
This fixes coverage upload with v3.2 of the upload-artifact option and later.

See https://github.com/actions/upload-artifact/issues/602. See also https://hypothes-is.slack.com/archives/C4K6M7P5E/p1725285976308269.