### PR TITLE
Upgrade both upload/download artifact GHA

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       {% endif %}
       {% if job == 'coverage' %}
       - name: Download coverage files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
       {% endif %}
@@ -122,7 +122,7 @@ jobs:
       {% endif %}
       {% if job == 'tests' %}
       - name: Upload coverage file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: .coverage.*


### PR DESCRIPTION
Dependabot has issued an upgrade due to a security concern in the download portion to the latest v4. Both upload and download much match the same major version so we'll upgrade both here.

See: https://hypothes-is.slack.com/archives/C4K6M7P5E/p1726646678298009