### PR TITLE
Remove references to `hdev`

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -195,11 +195,6 @@ module= [
   "tests.*",
 ]
 ignore_errors = true
-
-
-[tool.hdev]
-project_name = "{{ cookiecutter.slug }}"
-project_type = "{{ cookiecutter.__hdev_project_type }}"
 {% if include_exists("pyproject.toml") %}
 
 {{ include("pyproject.toml") -}}

--- a/bin/find_repos
+++ b/bin/find_repos
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Return the list of all cookiecuttered repos in the hypothesis GitHub organization.
 
-gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false -repo:hypothesis/hdev' -q '.items | .[] | .full_name'
+gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name'

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -22,7 +22,6 @@
     "__copyright_year": "{% now 'utc', '%Y' %}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pyapp",
-    "__hdev_project_type": "application",
     "__ignore__": "",
     "__target_dir__": "",
     "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true},

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -21,7 +21,6 @@
     "__copyright_year": "{% now 'utc', '%Y' %}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pypackage",
-    "__hdev_project_type": "library",
     "__ignore__": "",
     "__target_dir__": "",
     "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true},

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -24,7 +24,6 @@
     "__github_url": "https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.slug }}",
     "_extensions": ["local_extensions.LocalJinja2Extension"],
     "_directory": "pyramid-app",
-    "__hdev_project_type": "application",
     "__ignore__": "",
     "__target_dir__": "",
     "__copyright_year": "2022",


### PR DESCRIPTION
`hdev` is (finally) no longer used by any of our projects and its repo
is now archived. Slack thread:

https://hypothes-is.slack.com/archives/C1MA4E9B9/p1728289419454279
