### PR TITLE
Fix coverage on CI when multiple Python versions

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Download coverage files
         uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-python*
+          merge-multiple: true
       {% endif %}
       - run: python -m pip install 'tox<4'
       {% if job == 'format' %}
@@ -124,7 +125,7 @@ jobs:
       - name: Upload coverage file
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-python{% raw %}${{ matrix.python-version}}{% endraw +%}
           path: .coverage.*
           include-hidden-files: true
       {% endif %}


### PR DESCRIPTION
This was broken by the upgrade to `upload-artifact@v4`, see:
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
