### PR TITLE
Add *.tsbuildinfo files (TypeScript build cache) to .gitignore

### DIFF
--- a/_shared/project/.gitignore
+++ b/_shared/project/.gitignore
@@ -11,6 +11,7 @@ supervisord.pid
 .DS_Store
 .devdata*
 .eslintcache
+*.tsbuildinfo
 {% if include_exists("gitignore") %}
   {{- include("gitignore") -}}
 {% endif %}


### PR DESCRIPTION
These files started appearing after updating to TypeScript 5.6. See https://github.com/hypothesis/h/pull/8992.