### PR TITLE
Exclude `if TYPE_CHECKING:` blocks from coverage

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -78,6 +78,17 @@ show_missing = true
 precision = 2
 fail_under = 100.00
 skip_covered = true
+exclude_also = [
+{% if include_exists("coverage/exclude_also") %}
+    {{- include("coverage/exclude_also", indent=4) -}}
+{% else %}
+    # `if TYPE_CHECKING:` blocks are only executed while running mypy.
+    "if TYPE_CHECKING:",
+{% if include_exists("coverage/exclude_also/tail") %}
+    {{- include("coverage/exclude_also/tail", indent=4) -}}
+{% endif %}
+{% endif %}
+]
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
This is extracted from
https://github.com/hypothesis/cookiecutters/pull/188 as a separate PR.

This commit also adds includes for per-project overriding or extending
of the coverage excludes:

* If a project has a `.cookiecutter/includes/coverage/exclude_also` file
  that will _replace_ the cookiecutter's default `exclude_also`'s

* If a project has a `.cookiecutter/includes/coverage/exclude_also/tail` file
  that will _extend_ the cookiecutter's default `exclude_also`'s

Also fix a bug in `local_extensions.py`'s `include_exists(path)` function:
don't crash if there's a _folder_ (rather than a file) at `path` (the
code was catching the wrong exception class, looks like just a mistake).
