### PR TITLE
Enable mypy's `check_untyped_defs` option

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -181,6 +181,7 @@ pretty = true
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+check_untyped_defs = true
 
 disable_error_code = [
     # https://mypy.readthedocs.io/en/stable/error_code_list.html#code-import-untyped


### PR DESCRIPTION
Extracted from https://github.com/hypothesis/cookiecutters/pull/188 as a separate PR.

> Type-checks the interior of functions without type annotations.

https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs
