### PR TITLE
Add mypy ignore modules includes

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -213,9 +213,16 @@ exclude = [
 {% endif %}
 
 [[tool.mypy.overrides]]
-module= [
-  # Don't try to typecheck the tests for now
+module = [
+{% if include_exists("mypy/ignore_errors_modules") %}
+    {{- include("mypy/ignore_errors_modules", indent=2) -}}
+{% else %}
+  # Don't try to typecheck the tests for now.
   "tests.*",
+{% endif %}
+{% if include_exists("mypy/ignore_errors_modules/tail") %}
+   {{- include("mypy/ignore_errors_modules/tail", indent=2) -}}
+{% endif %}
 ]
 ignore_errors = true
 {% if include_exists("pyproject.toml") %}


### PR DESCRIPTION
Add a couple of includes for per-project customisation of which modules
we tell mypy to ignore.

This also tidies up the formatting of this section of pyproject.toml a
little, which unfortunately will mean a change to every single project.

This is extracted from
https://github.com/hypothesis/cookiecutters/pull/188 as a separate PR.
