### PR TITLE
Add an option to use Ruff (instead of Pylint, Black, isort, etc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ test sure: test-pypackage test-pyapp test-pyramid-app
 
 .PHONY: test-pypackage
 test-pypackage:
-	@bin/make_test pypackage console_script=yes devdata=yes postgres=yes pypi=yes
+	@bin/make_test pypackage console_script=yes devdata=yes postgres=yes pypi=yes linter=ruff
 
 .PHONY: test-pyapp
 test-pyapp:
-	@bin/make_test pyapp devdata=yes docker=yes postgres=yes
+	@bin/make_test pyapp devdata=yes docker=yes postgres=yes linter=ruff
 
 .PHONY: test-pyramid-app
 test-pyramid-app:
-	@bin/make_test pyramid-app devdata=yes docker=yes frontend=yes postgres=yes __postgres_port=5439
+	@bin/make_test pyramid-app devdata=yes docker=yes frontend=yes postgres=yes __postgres_port=5439 linter=ruff

--- a/_shared/hooks/post_gen_project.py
+++ b/_shared/hooks/post_gen_project.py
@@ -57,6 +57,10 @@ def remove_conditional_files():
     paths_to_remove.extend([".github/workflows/pypi.yml"])
     {% endif %}
 
+    {% if cookiecutter.get("linter") == "ruff" %}
+    paths_to_remove.extend(["tests/pyproject.toml", "setup.cfg"])
+    {% endif %}
+
     {% if cookiecutter.get("console_script") != "yes" %}
     paths_to_remove.extend(["src/{{ cookiecutter.package_name }}/__main__.py"])
     paths_to_remove.extend(["src/{{ cookiecutter.package_name }}/cli.py"])
@@ -102,6 +106,10 @@ def remove_project_files(target_dir):
         ".cookiecutter/includes/setuptools/install_requires",
         ".cookiecutter/includes/setuptools/console_scripts",
         ".cookiecutter/includes/setuptools/entry_points",
+        {% if cookiecutter.get("linter") == "ruff" %}"tests/pyproject.toml",{% endif +%}
+        {% if cookiecutter.get("linter") == "ruff" %}"setup.cfg",{% endif +%}
+        {% if cookiecutter.get("linter") == "ruff" %}".cookiecutter/includes/setup.cfg",{% endif +%}
+        {% if cookiecutter.get("linter") == "ruff" %}".cookiecutter/includes/pycodestyle",{% endif +%}
     ]
 
     for path in paths_to_remove:

--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -68,6 +68,18 @@ $(call help,make lint,"lint the code and print any warnings")
 lint: python
 	@pyenv exec tox -qe lint
 
+{% if cookiecutter.get("linter") == "ruff" %}
+.PHONY: fix
+$(call help,make fix,"apply fixes to resolve lint violations")
+fix: python
+	@pyenv exec tox -qe lint -- ruff check --fix-only {{ cookiecutter.package_name}} tests bin
+
+.PHONY: noqa
+$(call help,make noqa,"add noqa comments to suppress lint violations")
+noqa: python
+	@pyenv exec tox -qe lint -- ruff check --add-noqa {{ cookiecutter.package_name}} tests bin
+
+{% endif %}
 .PHONY: typecheck
 $(call help,make typecheck,"type check the code and print any warnings")
 typecheck: python

--- a/_shared/project/migrations/env.py
+++ b/_shared/project/migrations/env.py
@@ -4,7 +4,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from {{ cookiecutter.package_name }} import models
+from {{ cookiecutter.package_name }} import models{% if cookiecutter.get("linter") == "ruff" %}  # noqa: F401{% endif +%}
 from {{ cookiecutter.package_name }}.db import Base
 
 # this is the Alembic Config object, which provides

--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -59,6 +59,112 @@ filterwarnings = [
     {% endif %}
 ]
 
+{% if cookiecutter.get("linter") == "ruff" %}
+[tool.ruff]
+target-version = "py{{ python_versions()|oldest|pyformat(PyFormats.MAJOR_MINOR_FMT) }}"
+{% if include_exists("ruff/top_level/tail") %}
+{{ include("ruff/top_level/tail") -}}
+{% endif %}
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+{% if include_exists("ruff/lint/ignore") %}
+{{ include("ruff/lint/ignore", indent=4) -}}
+{% else %}
+    "UP",    # pyupgrade
+    "YTT",   # flake8-2020 (checks for misuse of sys.version or sys.version_info
+    "ANN",   # flake8-annotations (checks for absence of type annotations on functions)
+    "ASYNC", # flake8-async (checks for asyncio-related problems)
+    "S",     # flake8-bandit (checks for security issues)
+    "FBT",   # flake8-boolean-trap (checks for the "boolean trap" anti-pattern)
+    "B",     # flake8-bugbear (checks for bugs and design problems)
+    "A",     # flake8-builtins (checks for builtins being overridden)
+    "CPY",   # flake8-copyright (checks for missing copyright notices)
+    "C4",    # flake8-comprehensions (helps write better list/set/dict comprehensions)
+    "DTZ",   # flake8-datetimez (checks for usages of unsafe naive datetime class)
+    "T10",   # flake8-debugger (checks for set traces etc)
+    "EM",    # flake8-errmsg (checks for error message formatting issues)
+    "EXE",   # flake8-executable (checks for incorrect executable permissions and shebangs)
+    "FA",    # flake8-future-annotations (checks for missing from __future__ import annotations)
+    "ISC",   # flake8-implicit-str-concat (checks for style problems with string literal concatenation)
+    "ICN",   # flake8-import-conventions (checks for unconventional imports and aliases)
+    "LOG",   # flake8-logging (checks for issues with using the logging module)
+    "G",     # flake8-logging-format (enforce usage of `extra` in logging calls)
+    "INP",   # flake8-no-pep420 (checks for missing __init__.py files)
+    "PIE",   # flake8-pie (miscellaneous)
+    "T20",   # flake8-print (checks for print and pprint statements)
+    "PT",    # flake8-pytest-style (checks for common pytest style and consistency issues)
+    "RSE",   # flake8-raise (checks for issues with raising exceptions)
+    "RET",   # flake8-return (checks for issues with return values)
+    "SLOT",  # flake8-slots (requires __slots__ in subclasses of immutable types)
+    "SIM",   # flake8-simplify (lots of code simplification checks)
+    "TID",   # flake8-tidy-imports (checks for issues with imports)
+    "TC",    # flake8-type-checking (checks for type checking imports that aren't in TYPE_CHECKING blocks)
+    "ARG",   # flake8-unused-arguments (checks for unused arguments)
+    "PTH",   # flake8-use-pathlib (checks for cases with pathlib could be used but isn't)
+    "TD",    # flake8-todos (enforces good style for "# TODO" comments)
+    "FIX",   # flake8-fixme (checks for FIXMEs, TODOs, HACKs, etc)
+    "ERA",   # eradicate (checks for commented-out code)
+    "PGH",   # pygrep-hooks (miscellaneous)
+    "PL",    # pylint (miscellaneous rules from pylint)
+    "TRY",   # tryceratops (various try/except-related checks)
+    "FLY",   # flynt (checks for old-style %-formatted strings)
+    "PERF",  # perflint (checks for performance anti-patterns)
+    "FURB",  # refurb (various "refurbishing and modernizing" checks)
+    "DOC",   # pydoclint (docstring checks)
+    "RUF",   # Ruff-specific rules
+    "COM",   # flake8-commas (we used a code formatter so we don't need a linter to check this)
+    "D100","D101","D102","D103","D104","D105","D106","D107", # Missing docstrings.
+    "D202", # "No blank lines allowed after function docstring" conflicts with the Ruff code formatter.
+    # "Multi-line docstring summary should start at the first line" (D212)
+    # and "Multi-line docstring summary should start at the second line" (D213).
+    # These two rules conflict with each other so you have to disable one of them.
+    # How about we disable them both? PEP 257 says either approach is okay:
+    #
+    # > The summary line may be on the same line as the opening quotes or on
+    # > the next line.
+    # >
+    # > https://peps.python.org/pep-0257/#multi-line-docstrings
+    "D212", "D213",
+    "E501", # line-too-long (we use the code formatter so we don't need the linter to check line lengths for us).
+    "PLR2004", # "Magic value used in comparison", this mostly triggers false-positives related to HTTP status codes.
+    "PLR6301", # Method could be a function/classmethod/static method (doesn't use self)
+    "RET501", # Do not explicitly return None if it's the only possible return value.
+    "RET504", # Unnecessary assignment before return statement.
+{% if include_exists("ruff/lint/ignore/tail") %}
+{{ include("ruff/lint/ignore/tail", indent=4) -}}
+{% endif %}
+{% endif %}
+]
+
+[tool.ruff.lint.per-file-ignores]
+{% if include_exists("ruff/lint/per_file_ignores") %}
+{{ include("ruff/lint/per_file_ignores") -}}
+{% else %}
+"tests/*" = [
+    # Just disable name style checking for the tests, because we
+    # frequently use lots of argument names that don't conform.
+    # For example we frequently create pytest fixtures that aren't named in
+    # snake_case, such as a fixture that returns a mock of the FooBar class would
+    # be named FooBar in CamelCase.
+    "N",
+    "PLR0913", # Too many arguments. Tests often have lots of arguments.
+    "PLR0917", # Too many positional arguments. Tests often have lots of arguments.
+    "PLR0904", # Too many public methods. Test classes often have lots of test methods.
+]
+"__init__.py" = [
+    "F401", # Ignore unused import errors on __init__ files to avoid having to add either a noqa stament or an __all__ declaration.
+]
+{% if include_exists("ruff/lint/per_file_ignores/tail") %}
+{{ include("ruff/lint/per_file_ignores/tail") -}}
+{% endif %}
+{% endif %}
+{% if include_exists("ruff/tail") %}
+
+{{ include("ruff/tail") -}}
+{% endif %}
+{% else %}
 [tool.pydocstyle]
 ignore = [
     # Missing docstrings.
@@ -89,6 +195,7 @@ ignore = [
 {{ include("pydocstyle/ignores", indent=4) -}}
 {% endif %}
 ]
+{% endif %}
 
 [tool.coverage.run]
 branch = true
@@ -127,6 +234,7 @@ exclude_also = [
 {% endif %}
 ]
 
+{% if cookiecutter.get("linter") != "ruff" %}
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
@@ -221,6 +329,7 @@ good-names = [
 [tool.pylint.reports]
 output-format = "colorized"
 score = "no"
+{% endif %}
 
 [tool.mypy]
 allow_untyped_globals = true

--- a/_shared/project/requirements/checkformatting.in
+++ b/_shared/project/requirements/checkformatting.in
@@ -1,7 +1,11 @@
 pip-tools
 pip-sync-faster
+{% if cookiecutter.get("linter") == "ruff" %}
+ruff
+{% else %}
 black
 isort
+{% endif %}
 {% if include_exists("requirements/checkformatting.in") %}
     {{- include("requirements/checkformatting.in") -}}
 {% endif %}

--- a/_shared/project/requirements/format.in
+++ b/_shared/project/requirements/format.in
@@ -1,7 +1,11 @@
 pip-tools
 pip-sync-faster
+{% if cookiecutter.get("linter") == "ruff" %}
+ruff
+{% else %}
 black
 isort
+{% endif %}
 {% if include_exists("requirements/format.in") %}
     {{- include("requirements/format.in") -}}
 {% endif %}

--- a/_shared/project/requirements/lint.in
+++ b/_shared/project/requirements/lint.in
@@ -2,10 +2,14 @@ pip-tools
 pip-sync-faster
 -r tests.txt
 -r functests.txt
+{% if cookiecutter.get("linter") == "ruff" %}
+ruff
+{% else %}
 toml # Needed for pydocstyle to support pyproject.toml.
 pylint>=3.0.0
 pydocstyle
 pycodestyle
+{% endif %}
 {% if include_exists("requirements/lint.in") %}
     {{- include("requirements/lint.in") -}}
 {% endif %}

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -66,12 +66,16 @@ deps =
     pip-sync-faster
 {% elif cookiecutter._directory == 'pypackage' %}
     dev: ipython
+{% if cookiecutter.get("linter") == "ruff" %}
+    format,checkformatting,lint: ruff
+{% else %}
     format,checkformatting: black
     format,checkformatting: isort
     lint: toml
     lint: pylint>=3.0.0
     lint: pydocstyle
     lint: pycodestyle
+{% endif %}
     lint,tests: pytest-mock
     lint,tests,functests: pytest
     lint,tests,functests: h-testkit
@@ -117,6 +121,13 @@ commands =
 {% endif %}
 {% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
+    {% if cookiecutter.get("linter") == "ruff" %}
+    format: ruff check --select I --fix {{ cookiecutter.package_name}} tests bin
+    format: ruff format {{ cookiecutter.package_name}} tests bin
+    checkformatting: ruff check --select I {{ cookiecutter.package_name}} tests bin
+    checkformatting: ruff format --check {{ cookiecutter.package_name}} tests bin
+    lint: {posargs:ruff check {{ cookiecutter.package_name}} tests bin}
+    {% else %}
     format: black {{ cookiecutter.package_name }} tests bin
     format: isort --atomic {{ cookiecutter.package_name }} tests bin
     checkformatting: black --check {{ cookiecutter.package_name }} tests bin
@@ -125,8 +136,16 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle {{ cookiecutter.package_name }} tests bin
     lint: pycodestyle {{ cookiecutter.package_name }} tests bin
+    {% endif %}
 {% else %}
     dev: {posargs:ipython --classic --no-banner --no-confirm-exit}
+    {% if cookiecutter.get("linter") == "ruff" %}
+    format: ruff check --select I --fix src tests bin
+    format: ruff format src tests bin
+    checkformatting: ruff check --select I src tests bin
+    checkformatting: ruff format --check src tests bin
+    lint: {posargs:ruff check src tests bin}
+    {% else %}
     format: black src tests bin
     format: isort --atomic src tests bin
     checkformatting: black --check src tests bin
@@ -135,6 +154,7 @@ commands =
     lint: pylint --rcfile=tests/pyproject.toml tests
     lint: pydocstyle src tests bin
     lint: pycodestyle src tests bin
+    {% endif %}
 {% endif %}
 {% if cookiecutter._directory == "pyramid-app" and cookiecutter.get("postgres") == "yes" %}
     {tests,functests}: python3 -m {{ cookiecutter.package_name }}.scripts.init_db --delete --create

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -14,6 +14,7 @@
     "devdata": ["no", "yes"],
     "postgres": ["no", "yes"],
     "docker": ["no", "yes"],
+    "linter": ["pylint", "ruff"],
     "__postgres_version": "15.3-alpine",
     "__postgres_port": "{{ random_port_number() }}",
     "__docker_namespace": "{{ cookiecutter.github_owner }}",

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -13,6 +13,7 @@
     "create_github_repo": ["no", "yes"],
     "dependabot_pip_interval": ["monthly", "weekly", "daily"],
     "pypi": ["no", "yes"],
+    "linter": ["pylint", "ruff"],
     "__postgres_version": "15.3-alpine",
     "__postgres_port": "{{ random_port_number() }}",
     "__entry_point": "{{ cookiecutter.slug }}",

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -17,6 +17,7 @@
     "__frontend_typechecking": "{{ cookiecutter.frontend }}",
     "postgres": ["no", "yes"],
     "docker": ["no", "yes"],
+    "linter": ["pylint", "ruff"],
     "__postgres_version": "15.3-alpine",
     "__postgres_port": "{{ random_port_number() }}",
     "__docker_namespace": "{{ cookiecutter.github_owner }}",

--- a/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/scripts/init_db.py
+++ b/pyramid-app/{{ cookiecutter.slug }}/{{ cookiecutter.package_name }}/scripts/init_db.py
@@ -8,7 +8,12 @@ Usage:
     python3 -m {{ cookiecutter.package_name }}.scripts.init_db --help
 
 """
+{% if cookiecutter.get("linter") == "pylint" %}
 # pylint:disable=import-outside-toplevel,unused-import
+{% else %}
+
+# ruff: noqa: PLC0415, F401
+{% endif %}
 import argparse
 import logging
 from os import environ
@@ -117,7 +122,7 @@ def main():
         stamped = is_stamped(engine)
 
     if args.create:
-        if stamped:  # pylint:disable=possibly-used-before-assignment
+        if stamped:{% if cookiecutter.get("linter") == "pylint" %}  # pylint:disable=possibly-used-before-assignment{% endif +%}
             log.warning("Not creating tables because the DB is stamped by Alembic")
         else:
             create(engine)


### PR DESCRIPTION
Add a `"linter": "ruff"` option to `cookiecutter.json` that uses ruff instead of pylint, black, isort, pycodestyle and pydocstyle.

Testing:

- [x] This PR adds the `linter=ruff` to the cookiecutter's tests, and CI is passing. (This means that when new packages, apps and Pyramid apps are generated from the cookiecutter with the `linter=ruff` option, `make sure` is passing in the freshly-generated projects.)
- [x] Check out any Hypothesis project and run `make template checkout=ruff-linter-seanh-2` _without_ making any changes to `cookiecutter.json` and it should _not_ make any changes to the project. I've tested this with test-pypackage, test-pyapp, and test-pyramid-app.
- If you add `"linter": "ruff"` to `cookiecutter.json` and run `make template checkout=ruff-linter-seanh-2` it should add working Ruff integration to the project. For projects with requirements files you'll have to run `make requirements`. You may have to run `make fix` and `make noqa` to fix and suppress Ruff warnings. And you should grep for `# pylint` comments and remove them. Other than that it should just work. Here are working PRs to change test-pypackage, test-pyapp and test-pyramid-app to ruff:
  - [x] https://github.com/hypothesis/test-pypackage/pull/83
  - [x] https://github.com/hypothesis/test-pyapp/pull/190
  - [x] https://github.com/hypothesis/test-pyramid-app/pull/269
- [x] Also here's a PR that applies it to Via: https://github.com/hypothesis/via/pull/1509