### PR TITLE
Only gitignore `build` directory at root of repository

### DIFF
--- a/_shared/project/.gitignore
+++ b/_shared/project/.gitignore
@@ -1,4 +1,4 @@
-build
+/build
 coverage
 node_modules
 yarn-error.log


### PR DESCRIPTION
In repositories which contain vendored copies of PDF.js for example, there is a `build` directory that is not at the root of the tree, which we don't want to exclude from Git.

The only `build` dir we want to include is the one at the root of the tree that contains compiled frontend assets.

Per https://git-scm.com/docs/gitignore:

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.