### PR TITLE
Add slack_notifications_workflows setting to cookiecutter.json

### DIFF
--- a/_shared/project/.github/workflows/slack.yml
+++ b/_shared/project/.github/workflows/slack.yml
@@ -1,7 +1,7 @@
 name: Slack
 on:
   workflow_run:
-    workflows: [CI{% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}, Deploy{% endif %}]
+    workflows: [CI{% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}, Deploy{% endif %}{{ cookiecutter.get("__slack_notifications_workflows", "") }}]
     types: [completed]
     branches: [main]
 jobs:

--- a/pyapp/cookiecutter.json
+++ b/pyapp/cookiecutter.json
@@ -32,5 +32,6 @@
     "__tests_runner_type": "ubuntu-latest",
     "__coverage_runner_type": "ubuntu-latest",
     "__functests_runner_type": "ubuntu-latest",
-    "__scheduled_workflows": ""
+    "__scheduled_workflows": "",
+    "__slack_notifications_workflows": ""
 }

--- a/pypackage/cookiecutter.json
+++ b/pypackage/cookiecutter.json
@@ -31,5 +31,6 @@
     "__tests_runner_type": "ubuntu-latest",
     "__coverage_runner_type": "ubuntu-latest",
     "__functests_runner_type": "ubuntu-latest",
-    "__scheduled_workflows": ""
+    "__scheduled_workflows": "",
+    "__slack_notifications_workflows": ""
 }

--- a/pyramid-app/cookiecutter.json
+++ b/pyramid-app/cookiecutter.json
@@ -36,5 +36,6 @@
     "__coverage_runner_type": "ubuntu-latest",
     "__functests_runner_type": "ubuntu-latest",
     "__gunicorn_bind": false,
-    "__scheduled_workflows": ""
+    "__scheduled_workflows": "",
+    "__slack_notifications_workflows": ""
 }


### PR DESCRIPTION
To enable extending which GitHub Actions workflows get notifications in
Slack if they fail.
