### PR TITLE
Handle `NotADirectoryError` in `include_exists()`

### DIFF
--- a/_shared/local_extensions.py
+++ b/_shared/local_extensions.py
@@ -150,7 +150,7 @@ class LocalJinja2Extension(Extension):
         try:
             with self._open(context, path):
                 return True
-        except (FileNotFoundError, IsADirectoryError):
+        except (FileNotFoundError, IsADirectoryError, NotADirectoryError):
             return False
 
     @pass_context


### PR DESCRIPTION
A recent commit removed this favor of `IsADirectoryError`. In fact both
exceptions need to be handled.
