### PR TITLE
Add per-job services includes for CI

### DIFF
--- a/_shared/project/.github/workflows/ci.yml
+++ b/_shared/project/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       {% if include_exists(".github/workflows/ci/services.yml") %}
         {{- include(".github/workflows/ci/services.yml", indent=6) -}}
       {% endif %}
+      {% if include_exists(".github/workflows/ci/services_" + job + ".yml") %}
+        {{- include(".github/workflows/ci/services_" + job + ".yml", indent=6) -}}
+      {% endif %}
     {% endif %}
     {% if cookiecutter._directory == 'pypackage' and (job == 'tests' or job == 'functests') %}
     strategy:


### PR DESCRIPTION
For example this allows a project to create a
`.cookiecutter/includes/.github/workflows/ci/services_functests.yml`
file containing any services that it wants to run on CI *only for the
functests job*.
