### PR TITLE
Don't send automated cookiecutter PRs to LMS for now

### DIFF
--- a/bin/find_repos
+++ b/bin/find_repos
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Return the list of all cookiecuttered repos in the hypothesis GitHub organization.
 
-gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name'
+gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false -repo:hypothesis/lms' -q '.items | .[] | .full_name'


### PR DESCRIPTION
Until we get it back in sync with the template.
