### PR TITLE
Tweak the pytest command for the unittests

### DIFF
--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -159,7 +159,7 @@ commands =
 {% if cookiecutter._directory == "pyramid-app" and cookiecutter.get("postgres") == "yes" %}
     {tests,functests}: python3 -m {{ cookiecutter.package_name }}.scripts.init_db --delete --create
 {% endif %}
-    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 {%- if cookiecutter.get("__parallel_unit_tests") %} --numprocesses logical --dist loadgroup {%- endif %} --failed-first --new-first --no-header --quiet {posargs:tests/unit/}
+    tests: python -m pytest --cov --cov-report= --cov-fail-under=0 {posargs:{%- if cookiecutter.get("__parallel_unit_tests") %}--numprocesses logical --dist loadgroup {% endif %}tests/unit/}
     functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
     coverage: coverage combine
     coverage: coverage report


### PR DESCRIPTION
Two tweaks:

1. Remove the command line options `--failed-first --new-first --no-header --quiet`.

   For some reason these were causing database deadlocks when running
   the unit tests in h.

   Also, I just don't think the cookiecutter / `tox.ini` should be
   forcing certain pytest options. The user can set `PYTEST_ADDOPTS` if
   they like to run pytest with certain command line options. `tox.ini`
   should stick to the minimum needed to run the tests.

2. Move the `--numprocesses logical --dist loadgroup` (which cause the
   unit tests to be run in parallel) into tox's default `{posargs}`.

   This means that when running `tox` or `make test` the tests will be
   run in parallel (if the project has the `__parallel_unit_tests`
   option enabled in its `cookiecutter.json`) but when running
   `tox tests/unit/foo/bar_test.py` the tests will not be run in
   parallel. This is good because:

   1. When running only a single test file it actually takes longer to
      run the tests in parallel due to the delay caused by bootstrapping
      several parallel worker processes.
   2. When running the tests in parallel `breakpoints()` don't work.

   So you don't generally want to run the tests in parallel when running
   only a single test file.

   We've been doing it this way for a while in h and it has worked well,
   this commit back-ports the change into the cookiecutter.
