### PR TITLE
Remove `PYTHONDEVMODE`

### DIFF
--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -29,7 +29,6 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: NEW_RELIC_APP_NAME = {env:NEW_RELIC_APP_NAME:{{ cookiecutter.slug }}}
     dev: NEW_RELIC_ENVIRONMENT = {env:NEW_RELIC_ENVIRONMENT:dev}
-    dev,tests,functests: PYTHONDEVMODE = {env:PYTHONDEVMODE:1}
     tests: COVERAGE_FILE = {env:COVERAGE_FILE:.coverage.{envname}}
 {% if cookiecutter.get("postgres") == "yes" %}
     dev: ALEMBIC_CONFIG = {env:ALEMBIC_CONFIG:conf/alembic.ini}


### PR DESCRIPTION
This is causing a load of warnings noise to be printed out whenever any tox command is run (`make test`, `make dev`, etc). No one's paying any attention to these messages, they're just annoying noise. And there's so many of them that they obscure any actually important messages that might be printed.

For example here's h starting up:

    $ make dev
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/supervisor/options.py:13: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/supervisor/supervisord.py:181: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/wv/91722td54njgpb667fkh5mm00000gn/T/init_db-stderr---supervisor-_wva43ur.log'>
    combined_map = {}
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/supervisor/supervisord.py:203: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/wv/91722td54njgpb667fkh5mm00000gn/T/init_db-stdout---supervisor-o7wsqowx.log'>
    for fd, dispatcher in combined_map.items():
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    init_elasticsearch (stderr) |   from cgi import parse_header
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    websocket (stderr)   |   from cgi import parse_header
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pyramid/asset.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    init_elasticsearch (stderr) |   import pkg_resources
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    init_elasticsearch (stderr) | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    init_elasticsearch (stderr) |   declare_namespace(pkg)
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    init_elasticsearch (stderr) | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    init_elasticsearch (stderr) |   declare_namespace(pkg)
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    init_elasticsearch (stderr) | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    init_elasticsearch (stderr) |   declare_namespace(pkg)
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pyramid/asset.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    websocket (stderr)   |   import pkg_resources
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    websocket (stderr)   | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    websocket (stderr)   |   declare_namespace(pkg)
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    websocket (stderr)   | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    websocket (stderr)   |   declare_namespace(pkg)
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    websocket (stderr)   | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    websocket (stderr)   |   declare_namespace(pkg)
    web (stderr)         | [2025-01-23 10:37:08 +0000] [40925] [INFO] Starting gunicorn 23.0.0
    web (stderr)         | [2025-01-23 10:37:08 +0000] [40925] [INFO] Listening at: http://0.0.0.0:5000 (40925)
    web (stderr)         | [2025-01-23 10:37:08 +0000] [40925] [INFO] Using worker: sync
    web (stderr)         | [2025-01-23 10:37:08 +0000] [40949] [INFO] Booting worker with pid: 40949
    worker (stderr)      | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    worker (stderr)      |   from cgi import parse_header
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    web (stderr)         |   from cgi import parse_header
    web (stderr)         | [2025-01-23 10:37:08 +0000] [40955] [INFO] Booting worker with pid: 40955
    worker (stderr)      | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pyramid/asset.py:2: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    worker (stderr)      |   import pkg_resources
    worker (stderr)      | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    worker (stderr)      | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    worker (stderr)      |   declare_namespace(pkg)
    worker (stderr)      | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    worker (stderr)      | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    worker (stderr)      |   declare_namespace(pkg)
    worker (stderr)      | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    worker (stderr)      | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    worker (stderr)      |   declare_namespace(pkg)
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pyramid/path.py:3: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    web (stderr)         |   import pkg_resources
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    web (stderr)         | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    web (stderr)         |   declare_namespace(pkg)
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    web (stderr)         | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    web (stderr)         |   declare_namespace(pkg)
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    web (stderr)         | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    web (stderr)         |   declare_namespace(pkg)
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    web (stderr)         |   from cgi import parse_header
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    websocket (stderr)   |   from crypt import crypt as _crypt
    init_db (stderr)     | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/webob/compat.py:5: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    init_db (stderr)     |   from cgi import parse_header
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pyramid/path.py:3: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    web (stderr)         |   import pkg_resources
    init_db (stderr)     | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pyramid/path.py:3: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    init_db (stderr)     |   import pkg_resources
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    web (stderr)         | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    web (stderr)         |   declare_namespace(pkg)
    init_db (stderr)     | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('paste')`.
    init_db (stderr)     | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    init_db (stderr)     |   declare_namespace(pkg)
    init_db (stderr)     | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    init_db (stderr)     | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    init_db (stderr)     |   declare_namespace(pkg)
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('repoze')`.
    web (stderr)         | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    web (stderr)         |   declare_namespace(pkg)
    init_db (stderr)     | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    init_db (stderr)     | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    init_db (stderr)     |   declare_namespace(pkg)
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/pkg_resources/__init__.py:3142: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('zope')`.
    web (stderr)         | Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    web (stderr)         |   declare_namespace(pkg)
    assets               | [10:37:08]
    assets               | Using gulpfile ~/GitHub/hypothesis/h/gulpfile.js
    assets               | [10:37:08] Starting 'watch'...
    assets               | [10:37:08] Starting 'watch-js'...
    assets               | [10:37:08] Starting 'watch-css'...
    assets               | [10:37:08]
    assets               | Starting 'watch-fonts'...
    assets               | [10:37:08] Starting 'watch-images'...
    assets               | [10:37:08] Starting 'watch-manifest'...
    init_db (stderr)     | Not creating tables because the DB is stamped by Alembic
    init_db (stderr)     | Not stamping DB because it's already stamped
    worker (stderr)      | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    worker (stderr)      |   from crypt import crypt as _crypt
    assets               | [10:37:09]
    assets               | JS build starting...
    assets               | [10:37:09] Starting 'build-css'...
    assets               | [10:37:09] Starting 'build-legacy-css'...
    assets               | [10:37:09] Starting 'build-tailwind-css'...
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    init_elasticsearch (stderr) |   from crypt import crypt as _crypt
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    web (stderr)         |   from crypt import crypt as _crypt
    websocket (stderr)   | 2025-01-23 10:37:09,196 [40926] [gunicorn.error:INFO] Starting gunicorn 23.0.0
    websocket (stderr)   | 2025-01-23 10:37:09,199 [40926] [gunicorn.error:INFO] Listening at: http://127.0.0.1:5001 (40926)
    websocket (stderr)   | 2025-01-23 10:37:09,200 [40926] [gunicorn.error:INFO] Using worker: h.streamer.Worker
    websocket (stderr)   | 2025-01-23 10:37:09,206 [40961] [gunicorn.error:INFO] Booting worker with pid: 40961
    websocket (stderr)   | 2025-01-23 10:37:09,207 [40961] [gunicorn.error:INFO] Made psycopg green
    web (stderr)         | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    web (stderr)         |   from crypt import crypt as _crypt
    websocket (stderr)   | 2025-01-23 10:37:09,271 [40962] [gunicorn.error:INFO] Booting worker with pid: 40962
    websocket (stderr)   | 2025-01-23 10:37:09,273 [40962] [gunicorn.error:INFO] Made psycopg green
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/gunicorn/workers/ggevent.py:38: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['urllib3.util (/Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/urllib3/util/__init__.py)', 'newrelic.packages.urllib3.util (/Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/newrelic/packages/urllib3/util/__init__.py)', 'urllib3.util.ssl_ (/Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/urllib3/util/ssl_.py)'].
    websocket (stderr)   |   monkey.patch_all()
    websocket (stderr)   | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/gunicorn/workers/ggevent.py:38: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['urllib3.util (/Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/urllib3/util/__init__.py)', 'newrelic.packages.urllib3.util (/Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/newrelic/packages/urllib3/util/__init__.py)', 'urllib3.util.ssl_ (/Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/urllib3/util/ssl_.py)'].
    websocket (stderr)   |   monkey.patch_all()
    init_elasticsearch   | Initializing Elasticsearch index
    init_elasticsearch (stderr) | /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/elasticsearch/connection/http_urllib3.py:258: DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.1.0. Instead access HTTPResponse.headers directly.
    init_elasticsearch (stderr) |   return response.status, response.getheaders(), raw_data
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/supervisor/supervisord.py:181: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/wv/91722td54njgpb667fkh5mm00000gn/T/init_elasticsearch-stderr---supervisor-kaf868ax.log'>
    combined_map = {}
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/supervisor/supervisord.py:203: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/wv/91722td54njgpb667fkh5mm00000gn/T/init_elasticsearch-stdout---supervisor-ca35hhvb.log'>
    for fd, dispatcher in combined_map.items():
    ResourceWarning: Enable tracemalloc to get the object allocation traceback
    worker               |
    worker               |  -------------- celery@pelagian v5.4.0 (opalescent)
    worker               | --- ***** -----
    worker               | -- ******* ---- macOS-15.2-arm64-arm-64bit 2025-01-23 10:37:10
    worker               | - *** --- * ---
    worker               | - ** ---------- [config]
    worker               | - ** ---------- .> app:         h:0x1114a5820
    worker               | - ** ---------- .> transport:   amqp://guest:**@localhost:5672//
    worker               | - ** ---------- .> results:     disabled://
    worker               | - *** --- * --- .> concurrency: 8 (prefork)
    worker               | -- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
    worker               | --- ***** -----
    worker               |  -------------- [queues]
    worker               |                 .> celery           exchange=celery(direct) key=celery
    worker               |                 .> indexer          exchange=indexer(direct) key=indexer
    worker               |
    worker               | [tasks]
    worker               |   . h.tasks.annotations.sync_annotation_slim
    worker               |   . h.tasks.cleanup.purge_deleted_annotations
    worker               |   . h.tasks.cleanup.purge_deleted_users
    worker               |   . h.tasks.cleanup.purge_expired_auth_tickets
    worker               |   . h.tasks.cleanup.purge_expired_authz_codes
    worker               |   . h.tasks.cleanup.purge_expired_tokens
    worker               |   . h.tasks.cleanup.purge_removed_features
    worker               |   . h.tasks.cleanup.report_num_deleted_annotations
    worker               |   . h.tasks.indexer.add_annotation
    worker               |   . h.tasks.indexer.delete_annotation
    worker               |   . h.tasks.indexer.report_job_queue_metrics
    worker               |   . h.tasks.indexer.sync_annotations
    worker               |   . h.tasks.job_queue.add_annotations_between_times
    worker               |   . h.tasks.job_queue.add_annotations_from_group
    worker               |   . h.tasks.job_queue.add_annotations_from_user
    worker               |   . h.tasks.mailer.send
    worker               |   . h.tasks.url_migration.move_annotations
    worker               |   . h.tasks.url_migration.move_annotations_by_url
    worker               |
    assets               | [10:37:10] Finished 'build-legacy-css' after 1.2 s
    assets               | [10:37:10] Finished 'build-tailwind-css' after 1.2 s
    assets               | [10:37:10] Finished 'build-css' after 1.2 s
    worker (stderr)      | [2025-01-23 10:37:10,561: WARNING/MainProcess] /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
    worker (stderr)      | whether broker connection retries are made during startup in Celery 6.0 and above.
    worker (stderr)      | If you wish to retain the existing behavior for retrying connections on startup,
    worker (stderr)      | you should set broker_connection_retry_on_startup to True.
    worker (stderr)      |   warnings.warn(
    worker (stderr)      |
    worker (stderr)      | [2025-01-23 10:37:10,570: INFO/MainProcess] Connected to amqp://guest:**@127.0.0.1:5672//
    worker (stderr)      | [2025-01-23 10:37:10,570: WARNING/MainProcess] /Users/seanh/GitHub/hypothesis/h/.tox/dev/lib/python3.11/site-packages/celery/worker/consumer/consumer.py:508: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
    worker (stderr)      | whether broker connection retries are made during startup in Celery 6.0 and above.
    worker (stderr)      | If you wish to retain the existing behavior for retrying connections on startup,
    worker (stderr)      | you should set broker_connection_retry_on_startup to True.
    worker (stderr)      |   warnings.warn(
    worker (stderr)      |
    worker (stderr)      | [2025-01-23 10:37:10,577: INFO/MainProcess] mingle: searching for neighbors
    assets               | [10:37:10] Starting 'build-manifest'...
    assets               | [10:37:10] Finished 'build-manifest' after 19 ms
    worker (stderr)      | [2025-01-23 10:37:11,598: INFO/MainProcess] mingle: all alone
    worker (stderr)      | [2025-01-23 10:37:11,624: INFO/MainProcess] celery@pelagian ready.
    assets               | [10:37:11] Starting 'build-manifest'...
    assets               | [10:37:11] Finished 'build-manifest' after 8.74 ms
    assets               | [10:37:12] Starting 'build-manifest'...
    assets               | [10:37:12] Finished 'build-manifest' after 38 ms
    assets               | [10:37:13] JS build completed.
    assets               | [10:37:13] Finished 'watch-js' after 4.29 s
    assets               | [10:37:13] Starting 'build-manifest'...
    assets               | [10:37:13] Finished 'build-manifest' after 20 ms
