### PR TITLE
Fix `make shell`'s `PYTHONPATH` hack

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -49,9 +49,9 @@ web: python
 $(call help,make shell,"launch a Python shell in this project's virtualenv")
 shell: python
 {% if cookiecutter._directory == 'pyapp' %}
-	@pyenv exec tox -qe dev --run-command 'ipython'
+	@PYTHONPATH=$(CURDIR) TOX_TESTENV_PASSENV=PYTHONPATH pyenv exec tox -qe dev --run-command 'ipython'
 {% elif cookiecutter._directory == 'pyramid-app' %}
-	@pyenv exec tox -qe dev --run-command 'pshell conf/development.ini'
+	@PYTHONPATH=$(CURDIR) TOX_TESTENV_PASSENV=PYTHONPATH pyenv exec tox -qe dev --run-command 'pshell conf/development.ini'
 {% else %}
 	@pyenv exec tox -qe dev
 {% endif %}

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -36,10 +36,6 @@ setenv =
     tests: DATABASE_URL = {env:UNITTESTS_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_tests}
     functests: DATABASE_URL = {env:FUNCTESTS_DATABASE_URL:postgresql://postgres@localhost:{{ cookiecutter['__postgres_port'] }}/{{ cookiecutter.package_name }}_functests}
 {% endif %}
-{% if cookiecutter._directory in ['pyapp', 'pyramid-app'] %}
-    # Make `import {{ cookiecutter.package_name }}` work in `make shell`.
-    dev: PYTHONPATH = .
-{% endif %}
 {% if cookiecutter._directory in ['pyramid-app'] %}
     dev: WEB_CONCURRENCY = {env:WEB_CONCURRENCY:2}
 {% endif %}


### PR DESCRIPTION
`tox.ini` contained a `PYTHONPATH` hack in order to make `make shell`
work in applications but this hack was breaking things, see:

https://hypothes-is.slack.com/archives/C4K6M7P5E/p1738234769593509?thread_ts=1738149746.523459&cid=C4K6M7P5E

Tweak it so that the custom `PYTHONPATH` is only set when running
`make shell` rather than whenever running any `tox -e dev ...` command.
