### PR TITLE
Fix `make db`

### DIFF
--- a/_shared/project/Makefile
+++ b/_shared/project/Makefile
@@ -18,7 +18,7 @@ $(call help,make db,initialize the DB and upgrade it to the latest migration)
 db: args?=upgrade head
 db: python
 	@tox -qe dev --run-command 'python3 -m {{ cookiecutter.package_name }}.scripts.init_db --create --stamp'
-	@tox -qe dev --run-command 'alembic $(args)'
+	@PYTHONPATH=$(CURDIR) TOX_TESTENV_PASSENV=PYTHONPATH tox -qe dev --run-command 'alembic $(args)'
 
 {% endif %}
 .PHONY: devdata

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -45,6 +45,7 @@ setenv =
 passenv =
     HOME
     PYTEST_ADDOPTS
+    PYTHONPATH
     dev: DEBUG
     dev: SENTRY_DSN
     dev: NEW_RELIC_LICENSE_KEY


### PR DESCRIPTION
This was broken by https://github.com/hypothesis/cookiecutters/pull/215:
it turns out `make db` also relies on the `PYTHONPATH` hack, not just
`make shell`.
