### PR TITLE
Exclude `_version.py` from coverage

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -177,6 +177,9 @@ omit = [
     {% if cookiecutter.get("_directory") == "pyapp" %}
     "*/{{ cookiecutter.package_name }}/app.py",
     {% endif %}
+    {% if cookiecutter.get("_directory") == "pyramid-app" %}
+    "*/{{ cookiecutter.package_name }}/_version.py",
+    {% endif %}
     {% if cookiecutter.get("_directory") == "pyramid-app" and cookiecutter.get("postgres") == "yes" %}
     "*/{{ cookiecutter.package_name }}/scripts/init_db.py",
     {% endif %}


### PR DESCRIPTION
It's causing a coverage failure in some projects.
