### PR TITLE
Remove pytest options from development environment

### DIFF
--- a/_shared/project/pyproject.toml
+++ b/_shared/project/pyproject.toml
@@ -44,7 +44,6 @@ Changelog = "{{ cookiecutter.__github_url }}/releases"
 {{ include("pyproject.toml/tail") }}
 {% endif %}
 [tool.pytest.ini_options]
-addopts = "-q"
 filterwarnings = [
     "error", # Fail the tests if there are any warnings.
     "ignore:^find_module\\(\\) is deprecated and slated for removal in Python 3.12; use find_spec\\(\\) instead$:DeprecationWarning:importlib",

--- a/_shared/project/tox.ini
+++ b/_shared/project/tox.ini
@@ -158,7 +158,7 @@ commands =
     {tests,functests}: python3 -m {{ cookiecutter.package_name }}.scripts.init_db --delete --create
 {% endif %}
     tests: python -m pytest --cov --cov-report= --cov-fail-under=0 {posargs:{%- if cookiecutter.get("__parallel_unit_tests") %}--numprocesses logical --dist loadgroup {% endif %}tests/unit/}
-    functests: python -m pytest --failed-first --new-first --no-header --quiet {posargs:tests/functional/}
+    functests: python -m pytest {posargs:tests/functional/}
     coverage: coverage combine
     coverage: coverage report
 {% if cookiecutter._directory == "pypackage" %}


### PR DESCRIPTION
Remove pytest options like `-q`, `--failed-first`, `--new-first`, and
`--no-header` from the cookiecutter.

These kinds of options (controlling pytest's output and its test
execution order) are user preferences: the development environment's
defaults should just be pytest's defaults, and the user can customise
these (via the `PYTEST_ADDOPTS` envvar) if they please.

Also, most of these options were being passed to the functests but not
to the unittests. It should be consistent.
